### PR TITLE
Rename Class Variables and Fix Compilation

### DIFF
--- a/parser/xml_parser.h
+++ b/parser/xml_parser.h
@@ -36,7 +36,7 @@ namespace xml {
 
 class parser {
 public:
-	typedef Common::HashMap<Common::String, tag> tag_format_t;
+	typedef Common::HashMap<Common::String, tag> _tag_formatt;
 	typedef Common::Stack<tag *> tag_stack_t;
 
 	parser();
@@ -47,11 +47,11 @@ public:
 	bool read_binary_script(const char *fname);
 	bool is_script_binary(const char *fname) const;
 	bool is_script_binary() const {
-		return binary_script_;
+		return _binary_script;
 	}
 
 	const tag &root_tag() const {
-		return root_tag_;
+		return _root_tag;
 	}
 
 	void clear();
@@ -63,43 +63,43 @@ public:
 #endif
 
 	void resize_data_pool(unsigned int pool_sz) {
-		data_pool_.resize(pool_sz);
+		_data_pool.resize(pool_sz);
 	}
 
 	bool register_tag_format(const char *tag_name, const tag &tg) {
-		tag_format_t::iterator it = tag_format_.find(tag_name);
-		if (it != tag_format_.end())
+		_tag_formatt::iterator it = _tag_format.find(tag_name);
+		if (it != _tag_format.end())
 			return false;
 
-		tag_format_[tag_name] = tg;
+		_tag_format[tag_name] = tg;
 		return true;
 	}
 	const tag *get_tag_format(const char *tag_name) const {
-		tag_format_t::const_iterator it = tag_format_.find(tag_name);
-		if (it != tag_format_.end())
+		_tag_formatt::const_iterator it = _tag_format.find(tag_name);
+		if (it != _tag_format.end())
 			return &it->_value;
 
 		return NULL;
 	}
 
 	int num_tag_formats() const {
-		return tag_format_.size();
+		return _tag_format.size();
 	}
 
 private:
 
-	tag root_tag_;
+	tag _root_tag;
 
-	int data_pool_position_;
-	std::vector<char> data_pool_;
-	std::string data_buffer_;
+	int _data_pool_position;
+	std::vector<char> _data_pool;
+	std::string _data_buffer;
 
-	bool binary_script_;
+	bool _binary_script;
 
-	tag_stack_t tag_stack_;
-	tag_format_t tag_format_;
-	int cur_level_;
-	bool skip_mode_;
+	tag_stack_t _tag_stack;
+	_tag_formatt _tag_format;
+	int _cur_level;
+	bool _skip_mode;
 
 #ifndef _XML_ONLY_BINARY_SCRIPT_
 	bool read_tag_data(tag &tg, const char *data_ptr, int data_length);

--- a/parser/xml_parser.h
+++ b/parser/xml_parser.h
@@ -36,7 +36,7 @@ namespace xml {
 
 class parser {
 public:
-	typedef Common::HashMap<Common::String, tag> _tag_formatt;
+	typedef Common::HashMap<Common::String, tag> tag_format_t;
 	typedef Common::Stack<tag *> tag_stack_t;
 
 	parser();
@@ -67,7 +67,7 @@ public:
 	}
 
 	bool register_tag_format(const char *tag_name, const tag &tg) {
-		_tag_formatt::iterator it = _tag_format.find(tag_name);
+		tag_format_t::iterator it = _tag_format.find(tag_name);
 		if (it != _tag_format.end())
 			return false;
 
@@ -75,7 +75,7 @@ public:
 		return true;
 	}
 	const tag *get_tag_format(const char *tag_name) const {
-		_tag_formatt::const_iterator it = _tag_format.find(tag_name);
+		tag_format_t::const_iterator it = _tag_format.find(tag_name);
 		if (it != _tag_format.end())
 			return &it->_value;
 
@@ -97,7 +97,7 @@ private:
 	bool _binary_script;
 
 	tag_stack_t _tag_stack;
-	_tag_formatt _tag_format;
+	tag_format_t _tag_format;
 	int _cur_level;
 	bool _skip_mode;
 

--- a/parser/xml_tag.h
+++ b/parser/xml_tag.h
@@ -53,36 +53,36 @@ public:
 		TAG_DATA_STRING
 	};
 
-	tag(int id = 0, tag_data_format data_fmt = TAG_DATA_VOID, int data_sz = 0, int data_offs = 0) : ID_(id), data_format_(data_fmt), data_size_(data_sz), data_offset_(data_offs), data_(NULL) { }
-	tag(const tag &tg) : ID_(tg.ID_), data_format_(tg.data_format_), data_size_(tg.data_size_), data_offset_(tg.data_offset_), data_(tg.data_), subtags_(tg.subtags_) { }
+	tag(int id = 0, tag_data_format data_fmt = TAG_DATA_VOID, int data_sz = 0, int data_offs = 0) : _ID(id), _data_format(data_fmt), _data_size(data_sz), _data_offset(data_offs), _data(NULL) { }
+	tag(const tag &tg) : _ID(tg._ID), _data_format(tg._data_format), _data_size(tg._data_size), _data_offset(tg._data_offset), _data(tg._data), _subtags(tg._subtags) { }
 	~tag() { }
 	bool readTag(Common::SeekableReadStream *ff, tag &tg);
 
 	tag &operator = (const tag &tg) {
 		if (this == &tg) return *this;
 
-		ID_ = tg.ID_;
-		data_format_ = tg.data_format_;
-		data_size_ = tg.data_size_;
-		data_offset_ = tg.data_offset_;
+		_ID = tg._ID;
+		_data_format = tg._data_format;
+		_data_size = tg._data_size;
+		_data_offset = tg._data_offset;
 
-		subtags_ = tg.subtags_;
+		_subtags = tg._subtags;
 
 		return *this;
 	}
 
 	//! Возвращает идентификатор тега.
 	int ID() const {
-		return g_engine->_tagMap[ID_ - 1];
+		return g_engine->_tagMap[_ID - 1];
 	}
 
 	int origID() const {
-		return ID_;
+		return _ID;
 	}
 
 	//! Возвращает формат данных тега.
 	tag_data_format data_format() const {
-		return data_format_;
+		return _data_format;
 	}
 
 	//! Возвращает количество элеметов данных тега.
@@ -91,11 +91,11 @@ public:
 	умножить на размер элемента данных в байтах - data_elemet_size().
 	*/
 	int data_size() const {
-		return data_size_;
+		return _data_size;
 	}
 	//! Возвращает размер элемента данных тега в байтах.
 	int data_element_size() const {
-		switch (data_format_) {
+		switch (_data_format) {
 		case TAG_DATA_VOID:
 			return 0;
 		case TAG_DATA_SHORT:
@@ -115,58 +115,58 @@ public:
 
 	//! Устанавливает количество элементов данных тега.
 	void set_data_size(int sz) {
-		data_size_ = sz;
+		_data_size = sz;
 	}
 
 	//! Возвращает смещение до данных тега в данных парсера.
 	int data_offset() const {
-		return data_offset_;
+		return _data_offset;
 	}
 	//! Устанавливает смещение до данных тега в данных парсера.
 	void set_data_offset(int off) {
-		data_offset_ = off;
+		_data_offset = off;
 	}
 
 	//! Возвращает указатель на данные тега.
 	const char *data() const {
-		return &*(data_->begin() + data_offset_);
+		return &*(_data->begin() + _data_offset);
 	}
 
 	//! Устанавливает указатель на общие данные.
 	void set_data(const std::vector<char> *p) {
-		data_ = p;
+		_data = p;
 
-		for (subtags_t::iterator it = subtags_.begin(); it != subtags_.end(); ++it)
+		for (subtags_t::iterator it = _subtags.begin(); it != _subtags.end(); ++it)
 			it->set_data(p);
 	}
 
 	//! Очистка вложенных тегов.
 	void clear() {
-		subtags_.clear();
+		_subtags.clear();
 	}
 	//! Добавляет вложенный тег.
 	/**
 	Возвращает ссылку на последний вложенный тег.
 	*/
 	tag &add_subtag(const tag &tg) {
-		subtags_.push_back(tg);
-		return subtags_.back();
+		_subtags.push_back(tg);
+		return _subtags.back();
 	}
 	//! Возвращает true, если список вложенных тегов не пустой .
 	bool has_subtags() const {
-		return !subtags_.empty();
+		return !_subtags.empty();
 	}
 	//! Возвращает количество вложенных тэгов.
 	int num_subtags() const {
-		return subtags_.size();
+		return _subtags.size();
 	}
 	//! Возвращает итератор начала списка вложенных тегов.
 	subtag_iterator subtags_begin() const {
-		return subtags_.begin();
+		return _subtags.begin();
 	}
 	//! Возвращает итератор конца списка вложенных тегов.
 	subtag_iterator subtags_end() const {
-		return subtags_.end();
+		return _subtags.end();
 	}
 	//! Поиск вложенного тега по его идентификатору.
 	const tag *search_subtag(int subtag_id) const {
@@ -179,18 +179,18 @@ public:
 private:
 
 	//! Идентификатор (тип) тега.
-	int ID_;
+	int _ID;
 	//! Формат данных тега.
-	tag_data_format data_format_;
+	tag_data_format _data_format;
 	//! Количество элементов данных тега.
-	int data_size_;
+	int _data_size;
 	//! Смещение до данных тега в общих данных.
-	int data_offset_;
+	int _data_offset;
 	//! Указатель на данные.
-	const std::vector<char> *data_;
+	const std::vector<char> *_data;
 
 	//! Список вложенных тегов.
-	subtags_t subtags_;
+	subtags_t _subtags;
 };
 
 }; /* namespace xml */

--- a/parser/xml_tag_buffer.cpp
+++ b/parser/xml_tag_buffer.cpp
@@ -26,24 +26,24 @@ namespace QDEngine {
 
 namespace xml {
 
-tag_buffer::tag_buffer(const tag &tg) : data_size_(tg.data_size() * tg.data_element_size()),
-	data_offset_(0),
+tag_buffer::tag_buffer(const tag &tg) : _data_size(tg.data_size() * tg.data_element_size()),
+	_data_offset(0),
 #ifdef _DEBUG
 	data_format_(tg.data_format()),
 #endif
 	data_(tg.data()) {
 }
 
-tag_buffer::tag_buffer(const char *dp, int len) : data_size_(len),
-	data_offset_(0),
+tag_buffer::tag_buffer(const char *dp, int len) : _data_size(len),
+	_data_offset(0),
 #ifdef _DEBUG
 	data_format_(tag::TAG_DATA_VOID),
 #endif
 	data_(dp) {
 }
 
-tag_buffer::tag_buffer(const tag_buffer &tb) : data_size_(tb.data_size_),
-	data_offset_(tb.data_offset_),
+tag_buffer::tag_buffer(const tag_buffer &tb) : _data_size(tb._data_size),
+	_data_offset(tb._data_offset),
 #ifdef _DEBUG
 	data_format_(tb.data_format_),
 #endif
@@ -53,8 +53,8 @@ tag_buffer::tag_buffer(const tag_buffer &tb) : data_size_(tb.data_size_),
 tag_buffer &tag_buffer::operator = (const tag_buffer &tb) {
 	if (this == &tb) return *this;
 
-	data_size_ = tb.data_size_;
-	data_offset_ = tb.data_offset_;
+	_data_size = tb._data_size;
+	_data_offset = tb._data_offset;
 
 #ifdef _DEBUG
 	data_format_ = tb.data_format_;
@@ -69,40 +69,40 @@ tag_buffer::~tag_buffer() {
 
 tag_buffer &tag_buffer::operator >= (short &var) {
 	char *p;
-	var = (short)strtol(data_ + data_offset_, &p, 0);
-	data_offset_ += p - (data_ + data_offset_);
+	var = (short)strtol(data_ + _data_offset, &p, 0);
+	_data_offset += p - (data_ + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (unsigned short &var) {
 	char *p;
-	var = (unsigned short)strtoul(data_ + data_offset_, &p, 0);
-	data_offset_ += p - (data_ + data_offset_);
+	var = (unsigned short)strtoul(data_ + _data_offset, &p, 0);
+	_data_offset += p - (data_ + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (int &var) {
 	char *p;
-	var = (int)strtol(data_ + data_offset_, &p, 0);
-	data_offset_ += p - (data_ + data_offset_);
+	var = (int)strtol(data_ + _data_offset, &p, 0);
+	_data_offset += p - (data_ + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (unsigned int &var) {
 	char *p;
-	var = (unsigned int)strtoul(data_ + data_offset_, &p, 0);
-	data_offset_ += p - (data_ + data_offset_);
+	var = (unsigned int)strtoul(data_ + _data_offset, &p, 0);
+	_data_offset += p - (data_ + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (float &var) {
 	char *p;
-	var = (float)strtod(data_ + data_offset_, &p);
-	data_offset_ += p - (data_ + data_offset_);
+	var = (float)strtod(data_ + _data_offset, &p);
+	_data_offset += p - (data_ + _data_offset);
 
 	return *this;
 }

--- a/parser/xml_tag_buffer.cpp
+++ b/parser/xml_tag_buffer.cpp
@@ -31,7 +31,7 @@ tag_buffer::tag_buffer(const tag &tg) : _data_size(tg.data_size() * tg.data_elem
 #ifdef _DEBUG
 	data_format_(tg.data_format()),
 #endif
-	data_(tg.data()) {
+	_data(tg.data()) {
 }
 
 tag_buffer::tag_buffer(const char *dp, int len) : _data_size(len),
@@ -39,7 +39,7 @@ tag_buffer::tag_buffer(const char *dp, int len) : _data_size(len),
 #ifdef _DEBUG
 	data_format_(tag::TAG_DATA_VOID),
 #endif
-	data_(dp) {
+	_data(dp) {
 }
 
 tag_buffer::tag_buffer(const tag_buffer &tb) : _data_size(tb._data_size),
@@ -47,7 +47,7 @@ tag_buffer::tag_buffer(const tag_buffer &tb) : _data_size(tb._data_size),
 #ifdef _DEBUG
 	data_format_(tb.data_format_),
 #endif
-	data_(tb.data_) {
+	_data(tb._data) {
 }
 
 tag_buffer &tag_buffer::operator = (const tag_buffer &tb) {
@@ -59,7 +59,7 @@ tag_buffer &tag_buffer::operator = (const tag_buffer &tb) {
 #ifdef _DEBUG
 	data_format_ = tb.data_format_;
 #endif
-	data_ = tb.data_;
+	_data = tb._data;
 
 	return *this;
 }
@@ -69,40 +69,40 @@ tag_buffer::~tag_buffer() {
 
 tag_buffer &tag_buffer::operator >= (short &var) {
 	char *p;
-	var = (short)strtol(data_ + _data_offset, &p, 0);
-	_data_offset += p - (data_ + _data_offset);
+	var = (short)strtol(_data + _data_offset, &p, 0);
+	_data_offset += p - (_data + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (unsigned short &var) {
 	char *p;
-	var = (unsigned short)strtoul(data_ + _data_offset, &p, 0);
-	_data_offset += p - (data_ + _data_offset);
+	var = (unsigned short)strtoul(_data + _data_offset, &p, 0);
+	_data_offset += p - (_data + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (int &var) {
 	char *p;
-	var = (int)strtol(data_ + _data_offset, &p, 0);
-	_data_offset += p - (data_ + _data_offset);
+	var = (int)strtol(_data + _data_offset, &p, 0);
+	_data_offset += p - (_data + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (unsigned int &var) {
 	char *p;
-	var = (unsigned int)strtoul(data_ + _data_offset, &p, 0);
-	_data_offset += p - (data_ + _data_offset);
+	var = (unsigned int)strtoul(_data + _data_offset, &p, 0);
+	_data_offset += p - (_data + _data_offset);
 
 	return *this;
 }
 
 tag_buffer &tag_buffer::operator >= (float &var) {
 	char *p;
-	var = (float)strtod(data_ + _data_offset, &p);
-	_data_offset += p - (data_ + _data_offset);
+	var = (float)strtod(_data + _data_offset, &p);
+	_data_offset += p - (_data + _data_offset);
 
 	return *this;
 }

--- a/parser/xml_tag_buffer.h
+++ b/parser/xml_tag_buffer.h
@@ -52,35 +52,35 @@ public:
 
 	tag_buffer &operator > (short &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_SHORT);
-		var = (int16)READ_LE_UINT16(data_ + _data_offset);
+		var = (int16)READ_LE_UINT16(_data + _data_offset);
 		_data_offset += sizeof(int16);
 
 		return *this;
 	}
 	tag_buffer &operator > (unsigned short &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_UNSIGNED_SHORT);
-		var = READ_LE_UINT16(data_ + _data_offset);
+		var = READ_LE_UINT16(_data + _data_offset);
 		_data_offset += sizeof(uint16);
 
 		return *this;
 	}
 	tag_buffer &operator > (int &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_INT);
-		var = (int32)READ_LE_UINT32(data_ + _data_offset);
+		var = (int32)READ_LE_UINT32(_data + _data_offset);
 		_data_offset += sizeof(int32);
 
 		return *this;
 	}
 	tag_buffer &operator > (unsigned int &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_UNSIGNED_INT);
-		var = READ_LE_UINT32(data_ + _data_offset);
+		var = READ_LE_UINT32(_data + _data_offset);
 		_data_offset += sizeof(uint32);
 
 		return *this;
 	}
 	tag_buffer &operator > (float &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_FLOAT);
-		var = READ_LE_FLOAT32(data_ + _data_offset);
+		var = READ_LE_FLOAT32(_data + _data_offset);
 		_data_offset += 4;
 
 		return *this;
@@ -132,7 +132,7 @@ private:
 	tag::tag_data_format data_format_;
 #endif
 
-	const char *data_;
+	const char *_data;
 };
 
 }; /* namespace xml */

--- a/parser/xml_tag_buffer.h
+++ b/parser/xml_tag_buffer.h
@@ -52,36 +52,36 @@ public:
 
 	tag_buffer &operator > (short &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_SHORT);
-		var = (int16)READ_LE_UINT16(data_ + data_offset_);
-		data_offset_ += sizeof(int16);
+		var = (int16)READ_LE_UINT16(data_ + _data_offset);
+		_data_offset += sizeof(int16);
 
 		return *this;
 	}
 	tag_buffer &operator > (unsigned short &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_UNSIGNED_SHORT);
-		var = READ_LE_UINT16(data_ + data_offset_);
-		data_offset_ += sizeof(uint16);
+		var = READ_LE_UINT16(data_ + _data_offset);
+		_data_offset += sizeof(uint16);
 
 		return *this;
 	}
 	tag_buffer &operator > (int &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_INT);
-		var = (int32)READ_LE_UINT32(data_ + data_offset_);
-		data_offset_ += sizeof(int32);
+		var = (int32)READ_LE_UINT32(data_ + _data_offset);
+		_data_offset += sizeof(int32);
 
 		return *this;
 	}
 	tag_buffer &operator > (unsigned int &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_UNSIGNED_INT);
-		var = READ_LE_UINT32(data_ + data_offset_);
-		data_offset_ += sizeof(uint32);
+		var = READ_LE_UINT32(data_ + _data_offset);
+		_data_offset += sizeof(uint32);
 
 		return *this;
 	}
 	tag_buffer &operator > (float &var) {
 		XML_ASSERT(data_format_ == tag::TAG_DATA_VOID || data_format_ == tag::TAG_DATA_FLOAT);
-		var = READ_LE_FLOAT32(data_ + data_offset_);
-		data_offset_ += 4;
+		var = READ_LE_FLOAT32(data_ + _data_offset);
+		_data_offset += 4;
 
 		return *this;
 	}
@@ -118,15 +118,15 @@ public:
 	}
 
 	bool end_of_storage() const {
-		return data_size_ > data_offset_;
+		return _data_size > _data_offset;
 	}
 	void reset() {
-		data_offset_ = 0;
+		_data_offset = 0;
 	}
 
 private:
-	int data_size_;
-	int data_offset_;
+	int _data_size;
+	int _data_offset;
 
 #ifdef _DEBUG
 	tag::tag_data_format data_format_;

--- a/qd_fwd.h
+++ b/qd_fwd.h
@@ -23,6 +23,7 @@
 #define QDENGINE_QD_FWD_H
 
 #include <list>
+#include <string>
 
 namespace Common {
 class SeekableReadStream;
@@ -99,4 +100,3 @@ typedef std::list<qdFontInfo *> qdFontInfoList;
 } // namespace QDEngine
 
 #endif // QDENGINE_QD_FWD_H
-

--- a/qdcore/qd_animation.cpp
+++ b/qdcore/qd_animation.cpp
@@ -44,44 +44,44 @@
 
 namespace QDEngine {
 
-qdAnimation::qdAnimation() : parent_(NULL) {
-	tileAnimation_ = 0;
+qdAnimation::qdAnimation() : _parent(NULL) {
+	_tileAnimation = 0;
 
-	length_ = cur_time_ = 0.0f;
-	status_ = QD_ANIMATION_STOPPED;
+	_length = _cur_time = 0.0f;
+	_status = QD_ANIMATION_STOPPED;
 
-	sx_ = sy_ = 0;
+	_sx = _sy = 0;
 
-	is_finished_ = false;
+	_is_finished = false;
 
-	playback_speed_ = 1.0f;
+	_playback_speed = 1.0f;
 
-	frames_ptr = &frames;
-	scaled_frames_ptr_ = &scaled_frames_;
+	_frames_ptr = &frames;
+	_scaled_frames_ptr = &_scaled_frames;
 }
 
 qdAnimation::qdAnimation(const qdAnimation &anm) : qdNamedObject(anm), qdResource(anm),
-	parent_(anm.parent_),
-	length_(anm.length_),
-	cur_time_(anm.cur_time_),
-	status_(anm.status_),
-	is_finished_(anm.is_finished_),
-	sx_(anm.sx_),
-	sy_(anm.sy_),
-	num_frames_(anm.num_frames_),
-	playback_speed_(1.0f),
-	tileAnimation_(0) {
+	_parent(anm._parent),
+	_length(anm._length),
+	_cur_time(anm._cur_time),
+	_status(anm._status),
+	_is_finished(anm._is_finished),
+	_sx(anm._sx),
+	_sy(anm._sy),
+	_num_frames(anm._num_frames),
+	_playback_speed(1.0f),
+	_tileAnimation(0) {
 	copy_frames(anm);
 
-	if (anm.tileAnimation_)
-		tileAnimation_ = new grTileAnimation(*anm.tileAnimation_);
+	if (anm._tileAnimation)
+		_tileAnimation = new grTileAnimation(*anm._tileAnimation);
 }
 
 qdAnimation::~qdAnimation() {
 	clear_frames();
-	qda_file_.clear();
+	_qda_file.clear();
 
-	delete tileAnimation_;
+	delete _tileAnimation;
 }
 
 qdAnimation &qdAnimation::operator = (const qdAnimation &anm) {
@@ -90,51 +90,51 @@ qdAnimation &qdAnimation::operator = (const qdAnimation &anm) {
 	*static_cast<qdNamedObject *>(this) = anm;
 	*static_cast<qdResource *>(this) = anm;
 
-	parent_ = anm.parent_;
+	_parent = anm._parent;
 
-	length_ = anm.length_;
-	cur_time_ = anm.cur_time_;
-	status_ = QD_ANIMATION_STOPPED;
-	is_finished_ = false;
+	_length = anm._length;
+	_cur_time = anm._cur_time;
+	_status = QD_ANIMATION_STOPPED;
+	_is_finished = false;
 
-	playback_speed_ = anm.playback_speed_;
+	_playback_speed = anm._playback_speed;
 
-	sx_ = anm.sx_;
-	sy_ = anm.sy_;
+	_sx = anm._sx;
+	_sy = anm._sy;
 
 	copy_frames(anm);
 
-	num_frames_ = anm.num_frames_;
+	_num_frames = anm._num_frames;
 
-	delete tileAnimation_;
-	tileAnimation_ = 0;
+	delete _tileAnimation;
+	_tileAnimation = 0;
 
-	if (anm.tileAnimation_)
-		tileAnimation_ = new grTileAnimation(*anm.tileAnimation_);
+	if (anm._tileAnimation)
+		_tileAnimation = new grTileAnimation(*anm._tileAnimation);
 
 	return *this;
 }
 
 void qdAnimation::quant(float dt) {
-	if (status_ == QD_ANIMATION_PLAYING) {
+	if (_status == QD_ANIMATION_PLAYING) {
 		if (need_stop()) {
 			stop();
 			return;
 		}
 
-		cur_time_ += dt * playback_speed_;
-		if (cur_time_ >= length()) {
+		_cur_time += dt * _playback_speed;
+		if (_cur_time >= length()) {
 			if (length() > 0.01f) {
 				if (!check_flag(QD_ANIMATION_FLAG_LOOP)) {
-					cur_time_ = length() - 0.01f;
-					status_ = QD_ANIMATION_END_PLAYING;
+					_cur_time = length() - 0.01f;
+					_status = QD_ANIMATION_END_PLAYING;
 				} else {
-					cur_time_ = fmodf(cur_time_, length());
+					_cur_time = fmodf(_cur_time, length());
 				}
 			} else
-				cur_time_ = 0.0f;
+				_cur_time = 0.0f;
 
-			is_finished_ = true;
+			_is_finished = true;
 		}
 	}
 }
@@ -298,7 +298,7 @@ void qdAnimation::draw_contour(int x, int y, unsigned color, float scale) const 
 }
 
 qdAnimationFrame *qdAnimation::get_cur_frame() {
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 		if ((*iaf)->end_time() >= cur_time())
 			return *iaf;
 	}
@@ -307,7 +307,7 @@ qdAnimationFrame *qdAnimation::get_cur_frame() {
 }
 
 const qdAnimationFrame *qdAnimation::get_cur_frame() const {
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 		if ((*iaf)->end_time() >= cur_time())
 			return *iaf;
 	}
@@ -334,7 +334,7 @@ bool qdAnimation::add_frame(qdAnimationFrame *p, qdAnimationFrame *insert_pos, b
 				if (insert_after)
 					++iaf;
 				frames.insert(iaf, p);
-				num_frames_ = frames.size();
+				_num_frames = frames.size();
 				return true;
 			}
 		}
@@ -353,40 +353,40 @@ bool qdAnimation::add_frame(qdAnimationFrame *p, qdAnimationFrame *insert_pos, b
 }
 
 void qdAnimation::init_size() {
-	length_ = 0.0f;
+	_length = 0.0f;
 	if (!tileAnimation()) {
-		sx_ = sy_ = 0;
+		_sx = _sy = 0;
 
-		for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+		for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 			qdAnimationFrame *p = *iaf;
 
-			p->set_start_time(length_);
+			p->set_start_time(_length);
 
-			if (p->size_x() > sx_)
-				sx_ = p->size_x();
+			if (p->size_x() > _sx)
+				_sx = p->size_x();
 
-			if (p->size_y() > sy_)
-				sy_ = p->size_y();
+			if (p->size_y() > _sy)
+				_sy = p->size_y();
 
-			length_ += p->length();
+			_length += p->length();
 		}
 	} else {
-		for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+		for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 			qdAnimationFrame *p = *iaf;
 
-			p->set_start_time(length_);
+			p->set_start_time(_length);
 			p->set_size(tileAnimation()->frameSize());
 			p->set_picture_offset(Vect2i(0, 0));
 			p->set_picture_size(tileAnimation()->frameSize());
 
-			length_ += p->length();
+			_length += p->length();
 		}
 	}
 
-	if (cur_time_ >= length_)
-		cur_time_ = length_ - 0.01f;
+	if (_cur_time >= _length)
+		_cur_time = _length - 0.01f;
 
-	num_frames_ = frames_ptr->size();
+	_num_frames = _frames_ptr->size();
 }
 
 void qdAnimation::load_script(const xml::tag *p) {
@@ -459,26 +459,26 @@ void qdAnimation::free_resources() {
 	for (qdAnimationFrameList::iterator iaf = frames.begin(); iaf != frames.end(); ++iaf)
 		(*iaf)->free_resources();
 
-	for (qdAnimationFrameList::iterator iaf = scaled_frames_.begin(); iaf != scaled_frames_.end(); ++iaf)
+	for (qdAnimationFrameList::iterator iaf = _scaled_frames.begin(); iaf != _scaled_frames.end(); ++iaf)
 		(*iaf)->free_resources();
 }
 
 void qdAnimation::create_reference(qdAnimation *p, const qdAnimationInfo *inf) const {
-	p->frames_ptr = &frames;
-	p->scaled_frames_ptr_ = &scaled_frames_;
+	p->_frames_ptr = &frames;
+	p->_scaled_frames_ptr = &_scaled_frames;
 
 	p->clear_flags();
 	p->set_flag(flags() | QD_ANIMATION_FLAG_REFERENCE);
 
-	p->length_ = length_;
-	p->cur_time_ = 0.0f;
+	p->_length = _length;
+	p->_cur_time = 0.0f;
 
-	p->sx_ = sx_;
-	p->sy_ = sy_;
+	p->_sx = _sx;
+	p->_sy = _sy;
 
-	p->num_frames_ = num_frames_;
+	p->_num_frames = _num_frames;
 
-	debugC(1, kDebugTemp, "num_frames_: %d empty?: %d, is_empty()?: %d", num_frames_, frames.empty(), is_empty());
+	debugC(1, kDebugTemp, "num_frames_: %d empty?: %d, is_empty()?: %d", _num_frames, frames.empty(), is_empty());
 
 #ifndef __QD_SYSLIB__
 	if (inf) {
@@ -491,11 +491,11 @@ void qdAnimation::create_reference(qdAnimation *p, const qdAnimationInfo *inf) c
 		if (inf->check_flag(QD_ANIMATION_FLAG_FLIP_VERTICAL))
 			p->set_flag(QD_ANIMATION_FLAG_FLIP_VERTICAL);
 
-		p->playback_speed_ = inf->animation_speed();
+		p->_playback_speed = inf->animation_speed();
 	}
 #endif
 
-	p->parent_ = this;
+	p->_parent = this;
 }
 
 bool qdAnimation::hit(int x, int y) const {
@@ -544,13 +544,13 @@ bool qdAnimation::qda_load(const char *fname) {
 	}
 
 	int32 version = fh->readSint32LE();
-	sx_ = fh->readSint32LE();
-	sy_ = fh->readSint32LE();
-	length_ = fh->readFloatLE();
+	_sx = fh->readSint32LE();
+	_sy = fh->readSint32LE();
+	_length = fh->readFloatLE();
 	int32 fl = fh->readSint32LE();
 	int32 num_fr = fh->readSint32LE();
 
-	debugC(3, kDebugLoad, "qdAnimation::qda_load(): vers: %d sx: %d x %d len: %f fl: %d num_fr: %d", version, sx_, sy_, length_, fl, num_fr);
+	debugC(3, kDebugLoad, "qdAnimation::qda_load(): vers: %d sx: %d x %d len: %f fl: %d num_fr: %d", version, _sx, _sy, _length, fl, num_fr);
 
 	int num_scales = 0;
 	if (version >= 103) {
@@ -564,11 +564,11 @@ bool qdAnimation::qda_load(const char *fname) {
 
 	if (!tile_flag) {
 		if (num_scales) {
-			scales_.resize(num_scales);
+			_scales.resize(num_scales);
 			for (int i = 0; i < num_scales; i++)
-				scales_[i] = fh->readFloatLE();
+				_scales[i] = fh->readFloatLE();
 		} else
-			scales_.clear();
+			_scales.clear();
 
 		set_flag(fl & (QD_ANIMATION_FLAG_CROP | QD_ANIMATION_FLAG_COMPRESS));
 
@@ -581,13 +581,13 @@ bool qdAnimation::qda_load(const char *fname) {
 		for (int i = 0; i < num_fr * num_scales; i ++) {
 			qdAnimationFrame *p = new qdAnimationFrame;
 			p->qda_load(fh, version);
-			scaled_frames_.push_back(p);
+			_scaled_frames.push_back(p);
 		}
 	} else {
 		set_flag(fl);
 
-		sx_ = fh->readSint32LE();
-		sy_ = fh->readSint32LE();
+		_sx = fh->readSint32LE();
+		_sy = fh->readSint32LE();
 
 		for (int i = 0; i < num_fr; i ++) {
 			float start_time, length;
@@ -601,8 +601,8 @@ bool qdAnimation::qda_load(const char *fname) {
 		}
 
 		debugC(1, kDebugLoad, "qdAnimation::qda_load() tileAnimation %s", transCyrillic(fname));
-		tileAnimation_ = new grTileAnimation;
-		tileAnimation_->load(fh);
+		_tileAnimation = new grTileAnimation;
+		_tileAnimation->load(fh);
 	}
 
 	init_size();
@@ -612,15 +612,15 @@ bool qdAnimation::qda_load(const char *fname) {
 
 void qdAnimation::qda_set_file(const char *fname) {
 	if (fname)
-		qda_file_ = fname;
+		_qda_file = fname;
 	else
-		qda_file_.clear();
+		_qda_file.clear();
 }
 
 bool qdAnimation::crop() {
 	for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it)
 		(*it)->crop();
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it)
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it)
 		(*it)->crop();
 
 	return true;
@@ -629,7 +629,7 @@ bool qdAnimation::crop() {
 bool qdAnimation::undo_crop() {
 	for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it)
 		(*it)->undo_crop();
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it)
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it)
 		(*it)->undo_crop();
 
 	return true;
@@ -642,7 +642,7 @@ bool qdAnimation::compress() {
 	for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it) {
 		if (!(*it)->compress()) result = false;
 	}
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it) {
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it) {
 		if (!(*it)->compress()) result = false;
 	}
 
@@ -651,23 +651,23 @@ bool qdAnimation::compress() {
 }
 
 bool qdAnimation::tileCompress(grTileCompressionMethod method, int tolerance) {
-	if (!num_frames_ || check_flag(QD_ANIMATION_FLAG_TILE_COMPRESS)) return false;
+	if (!_num_frames || check_flag(QD_ANIMATION_FLAG_TILE_COMPRESS)) return false;
 
 	uncompress();
 	undo_crop();
 
 	grTileSprite::setComprasionTolerance(tolerance);
 
-	tileAnimation_ = new grTileAnimation;
-	tileAnimation_->init(num_frames_, Vect2i(sx_, sy_), frames.front()->check_flag(qdSprite::ALPHA_FLAG));
+	_tileAnimation = new grTileAnimation;
+	_tileAnimation->init(_num_frames, Vect2i(_sx, _sy), frames.front()->check_flag(qdSprite::ALPHA_FLAG));
 
-	for (int i = 0; i < num_frames_; i++)
-		tileAnimation_->addFrame((const unsigned *)get_frame(i)->data());
+	for (int i = 0; i < _num_frames; i++)
+		_tileAnimation->addFrame((const unsigned *)get_frame(i)->data());
 
 	if (method != TILE_UNCOMPRESSED)
-		tileAnimation_->compress(method);
+		_tileAnimation->compress(method);
 
-	tileAnimation_->compact();
+	_tileAnimation->compact();
 
 	set_flag(QD_ANIMATION_FLAG_TILE_COMPRESS);
 
@@ -682,7 +682,7 @@ bool qdAnimation::uncompress() {
 	for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it) {
 		if (!(*it)->uncompress()) result = false;
 	}
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it) {
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it) {
 		if (!(*it)->uncompress()) result = false;
 	}
 
@@ -692,7 +692,7 @@ bool qdAnimation::uncompress() {
 
 int qdAnimation::get_cur_frame_number() const {
 	int num = 0;
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 		if ((*iaf)->end_time() >= cur_time()) {
 			return num;
 		}
@@ -704,7 +704,7 @@ int qdAnimation::get_cur_frame_number() const {
 
 void qdAnimation::set_cur_frame(int number) {
 	int num = 0;
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 		if (num ++ == number) {
 			set_time((*iaf)->start_time() + (*iaf)->length() / 2.0f);
 			return;
@@ -782,7 +782,7 @@ bool qdAnimation::reverse_frame_range(int number0, int number1) {
 
 qdAnimationFrame *qdAnimation::get_frame(int number) {
 	int num = 0;
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf) {
 		if (num == number)
 			return *iaf;
 
@@ -806,27 +806,27 @@ bool qdAnimation::free_resource() {
 }
 
 void qdAnimation::advance_time(float tm) {
-	if (length_ <= 0.01f) return;
+	if (_length <= 0.01f) return;
 
-	tm *= playback_speed_;
+	tm *= _playback_speed;
 
-	if (cur_time_ + tm >= length()) {
+	if (_cur_time + tm >= length()) {
 		if (check_flag(QD_ANIMATION_FLAG_LOOP)) {
-			tm -= length() - cur_time_;
+			tm -= length() - _cur_time;
 			while (tm >= length())
 				tm -= length();
 
-			cur_time_ = tm;
+			_cur_time = tm;
 		} else
-			cur_time_ = length() - 0.01f;
+			_cur_time = length() - 0.01f;
 	} else
-		cur_time_ += tm;
+		_cur_time += tm;
 }
 
 int qdAnimation::picture_size_x() const {
 	int i = 0;
 	int sx = 0;
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf, i++) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf, i++) {
 		sx += (*iaf)->picture_size_x();
 	}
 
@@ -837,7 +837,7 @@ int qdAnimation::picture_size_x() const {
 int qdAnimation::picture_size_y() const {
 	int i = 0;
 	int sy = 0;
-	for (qdAnimationFrameList::const_iterator iaf = frames_ptr->begin(); iaf != frames_ptr->end(); ++iaf, i++) {
+	for (qdAnimationFrameList::const_iterator iaf = _frames_ptr->begin(); iaf != _frames_ptr->end(); ++iaf, i++) {
 		sy += (*iaf)->picture_size_y();
 	}
 
@@ -893,8 +893,8 @@ Vect2i qdAnimation::remove_edges() {
 		if (!(*iaf)->crop(left, top, right, bottom, false)) return Vect2i(0, 0);
 	}
 
-	sx_ -= left + right;
-	sy_ -= top + bottom;
+	_sx -= left + right;
+	_sy -= top + bottom;
 
 	if (crop_flag)
 		crop();
@@ -937,11 +937,11 @@ bool qdAnimation::load_data(Common::SeekableReadStream &fh, int save_version) {
 	char st, finished;
 	st = fh.readByte();
 	finished = fh.readByte();
-	cur_time_ = fh.readFloatLE();
-	length_ = fh.readFloatLE();
+	_cur_time = fh.readFloatLE();
+	_length = fh.readFloatLE();
 
-	status_ = st;
-	is_finished_ = (finished) ? true : false;
+	_status = st;
+	_is_finished = (finished) ? true : false;
 
 	debugC(2, kDebugSave, "  qdAnimation::load_data(): after %ld", fh.pos());
 	return true;
@@ -952,19 +952,19 @@ bool qdAnimation::save_data(Common::WriteStream &fh) const {
 
 	if (!qdNamedObject::save_data(fh)) return false;
 
-	if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && parent_) {
+	if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && _parent) {
 		fh.writeByte(1);
-		qdNamedObjectReference ref(parent_);
+		qdNamedObjectReference ref(_parent);
 
 		if (!ref.save_data(fh))
 			return false;
 	} else
 		fh.writeByte(0);
 
-	fh.writeByte(status_);
-	fh.writeByte(is_finished_);
-	fh.writeFloatLE(cur_time_);
-	fh.writeFloatLE(length_);
+	fh.writeByte(_status);
+	fh.writeByte(_is_finished);
+	fh.writeFloatLE(_cur_time);
+	fh.writeFloatLE(_length);
 
 	debugC(3, kDebugSave, "  qdAnimation::save_data(): after %ld", fh.pos());
 	return true;
@@ -987,20 +987,20 @@ bool qdAnimation::copy_frames(const qdAnimation &anm) {
 	if (!check_flag(QD_ANIMATION_FLAG_REFERENCE)) {
 		clear_frames();
 
-		frames_ptr = &frames;
+		_frames_ptr = &frames;
 
 		for (auto &it : anm.frames) {
 			frames.push_back(it->clone());
 		}
 
-		scaled_frames_ptr_ = &scaled_frames_;
+		_scaled_frames_ptr = &_scaled_frames;
 
-		for (auto &it : anm.scaled_frames_) {
-			scaled_frames_.push_back(it->clone());
+		for (auto &it : anm._scaled_frames) {
+			_scaled_frames.push_back(it->clone());
 		}
 	} else {
-		frames_ptr = anm.frames_ptr;
-		scaled_frames_ptr_ = anm.scaled_frames_ptr_;
+		_frames_ptr = anm._frames_ptr;
+		_scaled_frames_ptr = anm._scaled_frames_ptr;
 	}
 
 	return true;
@@ -1009,35 +1009,35 @@ bool qdAnimation::copy_frames(const qdAnimation &anm) {
 void qdAnimation::clear_frames() {
 	for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it)
 		delete *it;
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it)
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it)
 		delete *it;
 
 	frames.clear();
-	scaled_frames_.clear();
+	_scaled_frames.clear();
 }
 
 bool qdAnimation::add_scale(float value) {
 	if (fabs(value - 1.0f) <= 0.01f || value <= 0.01f) return false;
 
-	std::vector<float>::const_iterator it = std::find(scales_.begin(), scales_.end(), value);
-	if (it != scales_.end()) return false;
+	std::vector<float>::const_iterator it = std::find(_scales.begin(), _scales.end(), value);
+	if (it != _scales.end()) return false;
 
-	scales_.push_back(value);
-	std::sort(scales_.begin(), scales_.end());
+	_scales.push_back(value);
+	std::sort(_scales.begin(), _scales.end());
 	return true;
 }
 
 bool qdAnimation::create_scaled_frames() {
 	if (check_flag(QD_ANIMATION_FLAG_REFERENCE)) return false;
 
-	for (qdAnimationFrameList::iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it)
+	for (qdAnimationFrameList::iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it)
 		delete *it;
-	scaled_frames_.clear();
+	_scaled_frames.clear();
 
-	for (int i = 0; i < scales_.size(); i++) {
+	for (int i = 0; i < _scales.size(); i++) {
 		for (qdAnimationFrameList::iterator it = frames.begin(); it != frames.end(); ++it) {
-			scaled_frames_.push_back((*it)->clone());
-			scaled_frames_.back()->scale(scales_[i], scales_[i]);
+			_scaled_frames.push_back((*it)->clone());
+			_scaled_frames.back()->scale(_scales[i], _scales[i]);
 		}
 	}
 
@@ -1048,7 +1048,7 @@ int qdAnimation::get_scale_index(float &scale_value) const {
 	int index = -1;
 	float scl = 1.0f;
 
-	const std::vector<float> &scales_vect = (check_flag(QD_ANIMATION_FLAG_REFERENCE) && parent_) ? parent_->scales_ : scales_;
+	const std::vector<float> &scales_vect = (check_flag(QD_ANIMATION_FLAG_REFERENCE) && _parent) ? _parent->_scales : _scales;
 
 	for (int i = 0; i < scales_vect.size(); i++) {
 		if (fabs(scale_value - scl) > fabs(scale_value - scales_vect[i])) {
@@ -1065,8 +1065,8 @@ int qdAnimation::get_scale_index(float &scale_value) const {
 
 const qdAnimationFrame *qdAnimation::get_scaled_frame(int number, int scale_index) const {
 	int num = 0;
-	number += scale_index * num_frames_;
-	for (qdAnimationFrameList::const_iterator it = scaled_frames_ptr_->begin(); it != scaled_frames_ptr_->end(); ++it) {
+	number += scale_index * _num_frames;
+	for (qdAnimationFrameList::const_iterator it = _scaled_frames_ptr->begin(); it != _scaled_frames_ptr->end(); ++it) {
 		if (num++ == number)
 			return *it;
 	}
@@ -1081,7 +1081,7 @@ unsigned qdAnimation::resource_data_size() const {
 	for (qdAnimationFrameList::const_iterator it = frames.begin(); it != frames.end(); ++it)
 		size += (*it)->resource_data_size();
 
-	for (qdAnimationFrameList::const_iterator it = scaled_frames_.begin(); it != scaled_frames_.end(); ++it)
+	for (qdAnimationFrameList::const_iterator it = _scaled_frames.begin(); it != _scaled_frames.end(); ++it)
 		size += (*it)->resource_data_size();
 
 	return size;

--- a/qdcore/qd_animation.h
+++ b/qdcore/qd_animation.h
@@ -196,7 +196,7 @@ public:
 	bool tileCompress(grTileCompressionMethod method = TILE_UNCOMPRESSED, int tolerance = 0);
 
 	qdAnimationFrameList &frames_list() {
-		return frames;
+		return _frames;
 	};
 
 	void create_reference(qdAnimation *p, const qdAnimationInfo *inf = NULL) const;
@@ -207,7 +207,7 @@ public:
 
 	void clear() {
 		stop();
-		_frames_ptr = &frames;
+		_frames_ptr = &_frames;
 		_parent = NULL;
 	}
 
@@ -237,9 +237,9 @@ public:
 	//! Возвращает имя файла, в котором хранится анимация.
 	const char *resource_file() const {
 		if (!qda_file()) {
-			if (!check_flag(QD_ANIMATION_FLAG_REFERENCE) && !frames.empty()) {
-				if (frames.front()->has_file())
-					return frames.front()->file();
+			if (!check_flag(QD_ANIMATION_FLAG_REFERENCE) && !_frames.empty()) {
+				if (_frames.front()->has_file())
+					return _frames.front()->file();
 				else
 					return NULL;
 			} else
@@ -283,7 +283,7 @@ private:
 	int _num_frames;
 
 	const qdAnimationFrameList *_frames_ptr;
-	qdAnimationFrameList frames;
+	qdAnimationFrameList _frames;
 
 	const qdAnimationFrameList *_scaled_frames_ptr;
 	qdAnimationFrameList _scaled_frames;

--- a/qdcore/qd_animation.h
+++ b/qdcore/qd_animation.h
@@ -77,72 +77,72 @@ public:
 	const qdAnimationFrame *get_scaled_frame(int number, int scale_index) const;
 
 	int num_frames() const {
-		return num_frames_;
+		return _num_frames;
 	}
 
 	float length() const {
-		return length_;
+		return _length;
 	}
 	float cur_time() const {
-		return cur_time_;
+		return _cur_time;
 	}
 
 	void set_time(float tm) {
-		cur_time_ = tm;
+		_cur_time = tm;
 	}
 
 	float cur_time_rel() const {
-		if (length_ > 0.01f)
-			return cur_time_ / length_;
+		if (_length > 0.01f)
+			return _cur_time / _length;
 		return 0.0f;
 	}
 	void set_time_rel(float tm) {
 		if (tm < 0.0f) tm = 0.0f;
 		if (tm > 0.99f) tm = 0.99f;
-		cur_time_ = length_ * tm;
+		_cur_time = _length * tm;
 	}
 	void advance_time(float tm);
 
 	void init_size();
 	int size_x() const {
-		return sx_;
+		return _sx;
 	}
 	int size_y() const {
-		return sy_;
+		return _sy;
 	}
 
 	int picture_size_x() const;
 	int picture_size_y() const;
 
 	bool is_playing() const {
-		return (status_ == QD_ANIMATION_PLAYING ||
-		        status_ == QD_ANIMATION_END_PLAYING);
+		return (_status == QD_ANIMATION_PLAYING ||
+		        _status == QD_ANIMATION_END_PLAYING);
 	}
 
 	int status() const {
-		return status_;
+		return _status;
 	}
 	bool is_finished() const {
-		return is_finished_;
+		return _is_finished;
 	}
 	bool need_stop() const {
-		return status_ == QD_ANIMATION_END_PLAYING;
+		return _status == QD_ANIMATION_END_PLAYING;
 	}
 
 	void start() {
-		status_ = QD_ANIMATION_PLAYING;
-		is_finished_ = false;
-		cur_time_ = 0.0f;
+		_status = QD_ANIMATION_PLAYING;
+		_is_finished = false;
+		_cur_time = 0.0f;
 	}
 	void stop() {
-		status_ = QD_ANIMATION_STOPPED;
-		is_finished_ = true;
+		_status = QD_ANIMATION_STOPPED;
+		_is_finished = true;
 	}
 	void pause() {
-		status_ = QD_ANIMATION_PAUSED;
+		_status = QD_ANIMATION_PAUSED;
 	}
 	void resume() {
-		status_ = QD_ANIMATION_PLAYING;
+		_status = QD_ANIMATION_PLAYING;
 	}
 
 	void quant(float dt);
@@ -174,7 +174,7 @@ public:
 	bool save_script(Common::WriteStream &fh, int indent = 0) const;
 
 	const char *qda_file() const {
-		if (!qda_file_.empty()) return qda_file_.c_str();
+		if (!_qda_file.empty()) return _qda_file.c_str();
 		return 0;
 	}
 	void qda_set_file(const char *fname);
@@ -201,18 +201,18 @@ public:
 
 	void create_reference(qdAnimation *p, const qdAnimationInfo *inf = NULL) const;
 	bool is_reference(const qdAnimation *p) const {
-		if (p->check_flag(QD_ANIMATION_FLAG_REFERENCE) && p->parent_ == this) return true;
+		if (p->check_flag(QD_ANIMATION_FLAG_REFERENCE) && p->_parent == this) return true;
 		return false;
 	}
 
 	void clear() {
 		stop();
-		frames_ptr = &frames;
-		parent_ = NULL;
+		_frames_ptr = &frames;
+		_parent = NULL;
 	}
 
 	bool is_empty() const {
-		return (frames_ptr->empty());
+		return (_frames_ptr->empty());
 	}
 
 	//! Возвращает область экрана, занимаемую анимацией.
@@ -224,7 +224,7 @@ public:
 	grScreenRegion screen_region(int mode = 0, float scale = 1.0f) const;
 
 	const qdAnimation *parent() const {
-		return parent_;
+		return _parent;
 	}
 
 	// qdResource
@@ -260,43 +260,43 @@ public:
 	bool create_scaled_frames();
 
 	const std::vector<float> &scales() const {
-		if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && parent_) return parent_->scales_;
-		else return scales_;
+		if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && _parent) return _parent->_scales;
+		else return _scales;
 	}
 	void clear_scales() {
-		scales_.clear();
+		_scales.clear();
 	}
 
 private:
-	int sx_;
-	int sy_;
+	int _sx;
+	int _sy;
 
 	enum {
 		qda_version = 104
 	};
 
-	float length_;
-	float cur_time_;
+	float _length;
+	float _cur_time;
 
-	float playback_speed_;
+	float _playback_speed;
 
-	int num_frames_;
+	int _num_frames;
 
-	const qdAnimationFrameList *frames_ptr;
+	const qdAnimationFrameList *_frames_ptr;
 	qdAnimationFrameList frames;
 
-	const qdAnimationFrameList *scaled_frames_ptr_;
-	qdAnimationFrameList scaled_frames_;
-	std::vector<float> scales_;
+	const qdAnimationFrameList *_scaled_frames_ptr;
+	qdAnimationFrameList _scaled_frames;
+	std::vector<float> _scales;
 
-	grTileAnimation *tileAnimation_;
+	grTileAnimation *_tileAnimation;
 
-	int status_;
-	bool is_finished_;
+	int _status;
+	bool _is_finished;
 
-	std::string qda_file_;
+	std::string _qda_file;
 
-	const qdAnimation *parent_;
+	const qdAnimation *_parent;
 
 	int get_scale_index(float &scale_value) const;
 
@@ -304,10 +304,10 @@ private:
 	void clear_frames();
 
 	const grTileAnimation *tileAnimation() const {
-		if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && parent_)
-			return parent_->tileAnimation_;
+		if (check_flag(QD_ANIMATION_FLAG_REFERENCE) && _parent)
+			return _parent->_tileAnimation;
 		else
-			return tileAnimation_;
+			return _tileAnimation;
 	}
 };
 

--- a/qdcore/qd_animation_frame.cpp
+++ b/qdcore/qd_animation_frame.cpp
@@ -31,13 +31,13 @@
 
 namespace QDEngine {
 
-qdAnimationFrame::qdAnimationFrame() : start_time_(0.0f),
-	length_(0.0f) {
+qdAnimationFrame::qdAnimationFrame() : _start_time(0.0f),
+	_length(0.0f) {
 }
 
 qdAnimationFrame::qdAnimationFrame(const qdAnimationFrame &frm) : qdSprite(frm),
-	start_time_(frm.start_time_),
-	length_(frm.length_) {
+	_start_time(frm._start_time),
+	_length(frm._length) {
 }
 
 qdAnimationFrame::~qdAnimationFrame() {
@@ -49,8 +49,8 @@ qdAnimationFrame &qdAnimationFrame::operator = (const qdAnimationFrame &frm) {
 
 	*static_cast<qdSprite *>(this) = frm;
 
-	start_time_ = frm.start_time_;
-	length_ = frm.length_;
+	_start_time = frm._start_time;
+	_length = frm._length;
 
 	return *this;
 }
@@ -61,8 +61,8 @@ qdAnimationFrame *qdAnimationFrame::clone() const {
 
 void qdAnimationFrame::qda_load(Common::SeekableReadStream *fh, int version) {
 	/*int32 fl = */fh->readSint32LE();
-	start_time_ = fh->readFloatLE();
-	length_ = fh->readFloatLE();
+	_start_time = fh->readFloatLE();
+	_length = fh->readFloatLE();
 
 	qdSprite::qda_load(fh, version);
 }
@@ -77,4 +77,3 @@ void qdAnimationFrame::free_resources() {
 	free();
 }
 } // namespace QDEngine
-

--- a/qdcore/qd_animation_frame.h
+++ b/qdcore/qd_animation_frame.h
@@ -39,20 +39,20 @@ public:
 	qdAnimationFrame *clone() const;
 
 	float start_time() const {
-		return start_time_;
+		return _start_time;
 	}
 	float end_time() const {
-		return start_time_ + length_;
+		return _start_time + _length;
 	}
 	float length() const {
-		return length_;
+		return _length;
 	}
 
 	void set_start_time(float tm) {
-		start_time_ = tm;
+		_start_time = tm;
 	}
 	void set_length(float tm) {
-		length_ = tm;
+		_length = tm;
 	}
 
 	virtual void qda_load(class Common::SeekableReadStream *fh, int version = 100);
@@ -61,8 +61,8 @@ public:
 	void free_resources();
 
 private:
-	float start_time_;
-	float length_;
+	float _start_time;
+	float _length;
 };
 
 typedef std::list<qdAnimationFrame *> qdAnimationFrameList;
@@ -70,4 +70,3 @@ typedef std::list<qdAnimationFrame *> qdAnimationFrameList;
 } // namespace QDEngine
 
 #endif // QDENGINE_QDCORE_QD_ANIMATION_FRAME_H
-

--- a/qdcore/qd_animation_info.cpp
+++ b/qdcore/qd_animation_info.cpp
@@ -36,12 +36,12 @@
 
 namespace QDEngine {
 
-qdAnimationInfo::qdAnimationInfo() : speed_(0.0f), animation_speed_(1.0f) {
+qdAnimationInfo::qdAnimationInfo() : _speed(0.0f), _animation_speed(1.0f) {
 }
 
 qdAnimationInfo::qdAnimationInfo(const qdAnimationInfo &p) : qdNamedObject(p),
-	speed_(p.speed_),
-	animation_speed_(p.animation_speed_) {
+	_speed(p._speed),
+	_animation_speed(p._animation_speed) {
 }
 
 qdAnimationInfo::~qdAnimationInfo() {
@@ -53,10 +53,10 @@ void qdAnimationInfo::load_script(const xml::tag *p) {
 	for (xml::tag::subtag_iterator it = p->subtags_begin(); it != p->subtags_end(); ++it) {
 		switch (it->ID()) {
 		case QDSCR_SPEED:
-			xml::tag_buffer(*it) > speed_;
+			xml::tag_buffer(*it) > _speed;
 			break;
 		case QDSCR_ANIMATION_SPEED:
-			xml::tag_buffer(*it) > animation_speed_;
+			xml::tag_buffer(*it) > _animation_speed;
 			break;
 		case QDSCR_ANIMATION:
 			set_animation_name(it->data());
@@ -76,11 +76,11 @@ bool qdAnimationInfo::save_script(Common::WriteStream &fh, int indent) const {
 	if (flags())
 		res += Common::String::format(" flags=\"%d\"", flags());
 
-	if (speed_ > 0.01f)
-		res += Common::String::format(" speed=\"%f\"", speed_);
+	if (_speed > 0.01f)
+		res += Common::String::format(" speed=\"%f\"", _speed);
 
-	if (animation_speed_ != 1.0f)
-		res += Common::String::format(" animation_speed=\"%f\"", animation_speed_);
+	if (_animation_speed != 1.0f)
+		res += Common::String::format(" animation_speed=\"%f\"", _animation_speed);
 
 	if (animation_name())
 		res += Common::String::format(" animation=\"%s\"", qdscr_XML_string(animation_name()));
@@ -102,8 +102,8 @@ qdAnimationInfo &qdAnimationInfo::operator = (const qdAnimationInfo &p) {
 
 	*static_cast<qdNamedObject *>(this) = p;
 
-	speed_ = p.speed_;
-	animation_speed_ = p.animation_speed_;
+	_speed = p._speed;
+	_animation_speed = p._animation_speed;
 
 	return *this;
 }

--- a/qdcore/qd_animation_info.h
+++ b/qdcore/qd_animation_info.h
@@ -44,17 +44,17 @@ public:
 	}
 
 	float speed() const {
-		return speed_;
+		return _speed;
 	}
 	void set_speed(float sp) {
-		speed_ = sp;
+		_speed = sp;
 	}
 
 	float animation_speed() const {
-		return animation_speed_;
+		return _animation_speed;
 	}
 	void set_animation_speed(float sp) {
-		animation_speed_ = sp;
+		_animation_speed = sp;
 	}
 
 	qdAnimation *animation() const;
@@ -74,8 +74,8 @@ public:
 
 private:
 
-	float speed_;
-	float animation_speed_;
+	float _speed;
+	float _animation_speed;
 };
 
 typedef std::vector<qdAnimationInfo> qdAnimationInfoVector;

--- a/qdcore/qd_animation_maker.cpp
+++ b/qdcore/qd_animation_maker.cpp
@@ -28,18 +28,18 @@
 
 namespace QDEngine {
 
-qdAnimationMaker::qdAnimationMaker() : default_frame_length_(0.05f),
-	callback_data_(0),
-	progress_callback_(0) {
+qdAnimationMaker::qdAnimationMaker() : _default_frame_length(0.05f),
+	_callback_data(0),
+	_progress_callback(0) {
 }
 
 qdAnimationMaker::~qdAnimationMaker() {
 }
 
 maker_progress_fnc qdAnimationMaker::set_callback(maker_progress_fnc p, void *data) {
-	maker_progress_fnc old_p = progress_callback_;
-	progress_callback_ = p;
-	callback_data_ = data;
+	maker_progress_fnc old_p = _progress_callback;
+	_progress_callback = p;
+	_callback_data = data;
 
 	return old_p;
 }
@@ -48,7 +48,7 @@ bool qdAnimationMaker::insert_frame(class qdAnimation *p, const char *fname, int
 	// IMPORTANT(pabdulin): auto_ptr usage was removed
 	qdAnimationFrame *fp = new qdAnimationFrame;
 	fp->set_file(fname);
-	fp->set_length(default_frame_length_);
+	fp->set_length(_default_frame_length);
 
 	if (!fp->load_resources())
 		return false;
@@ -105,9 +105,9 @@ bool qdAnimationMaker::insert_frames(class qdAnimation *p, const char *folder, i
 			if (insert_frame(p, it.c_str(), insert_pos, insert_after, true))
 				result = true;
 
-			if (progress_callback_) {
+			if (_progress_callback) {
 				int percents = i++ * 100 / flist.size();
-				(*progress_callback_)(percents, callback_data_);
+				(*_progress_callback)(percents, _callback_data);
 			}
 		}
 		flist.clear();

--- a/qdcore/qd_animation_maker.h
+++ b/qdcore/qd_animation_maker.h
@@ -38,14 +38,14 @@ public:
 	maker_progress_fnc set_callback(maker_progress_fnc p, void *data = 0);
 
 	void set_default_frame_length(float len) {
-		default_frame_length_ = len;
+		_default_frame_length = len;
 	}
 
 private:
-	float default_frame_length_;    // длительность кадра по умолчанию (в секундах)
+	float _default_frame_length;    // длительность кадра по умолчанию (в секундах)
 
-	void *callback_data_;
-	maker_progress_fnc progress_callback_;
+	void *_callback_data;
+	maker_progress_fnc _progress_callback;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_animation_set.cpp
+++ b/qdcore/qd_animation_set.cpp
@@ -35,12 +35,12 @@ qdAnimationSet::qdAnimationSet() {
 qdAnimationSet::qdAnimationSet(const qdAnimationSet &set) : qdNamedObject(set),
 	_start_angle(set._start_angle),
 	_animations(set._animations),
-	walk_sound_frequency_(set.walk_sound_frequency_),
+	_walk_sound_frequency(set._walk_sound_frequency),
 	_static_animations(set._static_animations),
 	_start_animations(set._start_animations),
 	_stop_animations(set._stop_animations),
-	turn_animation_(set.turn_animation_) {
-	turn_animation_.set_owner(this);
+	_turn_animation(set._turn_animation) {
+	_turn_animation.set_owner(this);
 
 	for (int i = 0; i < size(); i ++) {
 		_animations[i].set_owner(this);
@@ -68,10 +68,10 @@ qdAnimationSet &qdAnimationSet::operator = (const qdAnimationSet &set) {
 	_static_animations = set._static_animations;
 	_start_animations = set._stop_animations;
 	_stop_animations = set._stop_animations;
-	walk_sound_frequency_ = set.walk_sound_frequency_;
+	_walk_sound_frequency = set._walk_sound_frequency;
 
-	turn_animation_ = set.turn_animation_;
-	turn_animation_.set_owner(this);
+	_turn_animation = set._turn_animation;
+	_turn_animation.set_owner(this);
 
 	for (int i = 0; i < size(); i ++) {
 		_animations[i].set_owner(this);
@@ -88,7 +88,7 @@ void qdAnimationSet::resize(int sz) {
 	_static_animations.resize(sz);
 	_start_animations.resize(sz);
 	_stop_animations.resize(sz);
-	walk_sound_frequency_.resize(sz, 1);
+	_walk_sound_frequency.resize(sz, 1);
 
 	for (int i = 0; i < size(); i ++) {
 		_animations[i].set_owner(this);
@@ -172,7 +172,7 @@ qdAnimationInfo *qdAnimationSet::get_stop_animation_info(float direction_angle) 
 }
 
 qdAnimation *qdAnimationSet::get_turn_animation() const {
-	return turn_animation_.animation();
+	return _turn_animation.animation();
 }
 
 void qdAnimationSet::load_script(const xml::tag *p) {
@@ -201,16 +201,16 @@ void qdAnimationSet::load_script(const xml::tag *p) {
 			index ++;
 			break;
 		case QDSCR_ANIMATION_SET_TURN:
-			turn_animation_.set_animation_name(it->data());
+			_turn_animation.set_animation_name(it->data());
 			break;
 		case QDSCR_ANIMATION_SET_START_ANGLE:
 			xml::tag_buffer(*it) > _start_angle;
 			break;
 		case QDSCR_OBJECT_STATE_WALK_SOUND_FREQUENCY: {
 			xml::tag_buffer buf(*it);
-			walk_sound_frequency_.resize(it->data_size());
+			_walk_sound_frequency.resize(it->data_size());
 			for (int i = 0; i < it->data_size(); i++)
-				buf > walk_sound_frequency_[i];
+				buf > _walk_sound_frequency[i];
 		}
 		break;
 		}
@@ -223,8 +223,8 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 	}
 	fh.writeString(Common::String::format("<animation_set name=\"%s\"", qdscr_XML_string(name())));
 
-	if (turn_animation_.animation_name()) {
-		fh.writeString(Common::String::format(" animation_turn=\"%s\"", qdscr_XML_string(turn_animation_.animation_name())));
+	if (_turn_animation.animation_name()) {
+		fh.writeString(Common::String::format(" animation_turn=\"%s\"", qdscr_XML_string(_turn_animation.animation_name())));
 	}
 
 	fh.writeString(Common::String::format(" size=\"%d\"", size()));
@@ -251,14 +251,14 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 		it.save_script(fh, indent + 1);
 	}
 
-	if (walk_sound_frequency_.size()) {
+	if (_walk_sound_frequency.size()) {
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
 
-		fh.writeString(Common::String::format("<walk_sound_frequency>%lu", walk_sound_frequency_.size()));
-		for (int i = 0; i < walk_sound_frequency_.size(); i++) {
-			fh.writeString(Common::String::format(" %f", walk_sound_frequency_[i]));
+		fh.writeString(Common::String::format("<walk_sound_frequency>%lu", _walk_sound_frequency.size()));
+		for (int i = 0; i < _walk_sound_frequency.size(); i++) {
+			fh.writeString(Common::String::format(" %f", _walk_sound_frequency[i]));
 		}
 
 		fh.writeString("</walk_sound_frequency>\r\n");
@@ -299,7 +299,7 @@ bool qdAnimationSet::load_animations(const qdNamedObject *res_owner) {
 			}
 		}
 
-		if (qdAnimation *p = turn_animation_.animation())
+		if (qdAnimation *p = _turn_animation.animation())
 			dp->load_resource(p, res_owner);
 
 		return true;
@@ -334,7 +334,7 @@ bool qdAnimationSet::free_animations(const qdNamedObject *res_owner) {
 			}
 		}
 
-		if (qdAnimation *p = turn_animation_.animation())
+		if (qdAnimation *p = _turn_animation.animation())
 			dp->release_resource(p, res_owner);
 
 		return true;
@@ -367,7 +367,7 @@ bool qdAnimationSet::scale_animations(float coeff_x, float coeff_y) {
 			if (!p->scale(coeff_x, coeff_y)) res = false;
 	}
 
-	if (qdAnimation *p = turn_animation_.animation())
+	if (qdAnimation *p = _turn_animation.animation())
 		if (!p->scale(coeff_x, coeff_y)) res = false;
 
 	return res;
@@ -391,7 +391,7 @@ bool qdAnimationSet::register_resources(const qdNamedObject *res_owner) {
 			if (qdAnimation *p = it.animation())
 				dp->register_resource(p, res_owner);
 		}
-		if (qdAnimation *p = turn_animation_.animation())
+		if (qdAnimation *p = _turn_animation.animation())
 			dp->register_resource(p, res_owner);
 		return true;
 	}
@@ -417,7 +417,7 @@ bool qdAnimationSet::unregister_resources(const qdNamedObject *res_owner) {
 			if (qdAnimation *p = it.animation())
 				dp->unregister_resource(p, res_owner);
 		}
-		if (qdAnimation *p = turn_animation_.animation())
+		if (qdAnimation *p = _turn_animation.animation())
 			dp->unregister_resource(p, res_owner);
 		return true;
 	}
@@ -433,10 +433,10 @@ float qdAnimationSet::adjust_angle(float angle) const {
 }
 
 float qdAnimationSet::walk_sound_frequency(int direction_index) const {
-	if (direction_index < 0 || direction_index >= walk_sound_frequency_.size())
+	if (direction_index < 0 || direction_index >= _walk_sound_frequency.size())
 		return 1;
 	else
-		return walk_sound_frequency_[direction_index];
+		return _walk_sound_frequency[direction_index];
 }
 
 float qdAnimationSet::walk_sound_frequency(float direction_angle) const {
@@ -447,9 +447,9 @@ float qdAnimationSet::walk_sound_frequency(float direction_angle) const {
 void qdAnimationSet::set_walk_sound_frequency(int direction_index, float freq) {
 	assert(direction_index >= 0);
 
-	if (direction_index >= walk_sound_frequency_.size())
-		walk_sound_frequency_.resize(direction_index + 1, 1);
+	if (direction_index >= _walk_sound_frequency.size())
+		_walk_sound_frequency.resize(direction_index + 1, 1);
 
-	walk_sound_frequency_[direction_index] = freq;
+	_walk_sound_frequency[direction_index] = freq;
 }
 } // namespace QDEngine

--- a/qdcore/qd_animation_set.cpp
+++ b/qdcore/qd_animation_set.cpp
@@ -29,32 +29,32 @@
 namespace QDEngine {
 
 qdAnimationSet::qdAnimationSet() {
-	start_angle_ = 0.0f;
+	_start_angle = 0.0f;
 }
 
 qdAnimationSet::qdAnimationSet(const qdAnimationSet &set) : qdNamedObject(set),
-	start_angle_(set.start_angle_),
-	animations_(set.animations_),
+	_start_angle(set._start_angle),
+	_animations(set._animations),
 	walk_sound_frequency_(set.walk_sound_frequency_),
-	static_animations_(set.static_animations_),
-	start_animations_(set.start_animations_),
-	stop_animations_(set.stop_animations_),
+	_static_animations(set._static_animations),
+	_start_animations(set._start_animations),
+	_stop_animations(set._stop_animations),
 	turn_animation_(set.turn_animation_) {
 	turn_animation_.set_owner(this);
 
 	for (int i = 0; i < size(); i ++) {
-		animations_[i].set_owner(this);
-		static_animations_[i].set_owner(this);
-		start_animations_[i].set_owner(this);
-		stop_animations_[i].set_owner(this);
+		_animations[i].set_owner(this);
+		_static_animations[i].set_owner(this);
+		_static_animations[i].set_owner(this);
+		_stop_animations[i].set_owner(this);
 	}
 }
 
 qdAnimationSet::~qdAnimationSet() {
-	animations_.clear();
-	static_animations_.clear();
-	start_animations_.clear();
-	stop_animations_.clear();
+	_animations.clear();
+	_static_animations.clear();
+	_start_animations.clear();
+	_stop_animations.clear();
 }
 
 qdAnimationSet &qdAnimationSet::operator = (const qdAnimationSet &set) {
@@ -62,43 +62,43 @@ qdAnimationSet &qdAnimationSet::operator = (const qdAnimationSet &set) {
 
 	*static_cast<qdNamedObject *>(this) = set;
 
-	start_angle_ = set.start_angle_;
+	_start_angle = set._start_angle;
 
-	animations_ = set.animations_;
-	static_animations_ = set.static_animations_;
-	start_animations_ = set.start_animations_;
-	stop_animations_ = set.stop_animations_;
+	_animations = set._animations;
+	_static_animations = set._static_animations;
+	_start_animations = set._stop_animations;
+	_stop_animations = set._stop_animations;
 	walk_sound_frequency_ = set.walk_sound_frequency_;
 
 	turn_animation_ = set.turn_animation_;
 	turn_animation_.set_owner(this);
 
 	for (int i = 0; i < size(); i ++) {
-		animations_[i].set_owner(this);
-		static_animations_[i].set_owner(this);
-		start_animations_[i].set_owner(this);
-		stop_animations_[i].set_owner(this);
+		_animations[i].set_owner(this);
+		_static_animations[i].set_owner(this);
+		_start_animations[i].set_owner(this);
+		_stop_animations[i].set_owner(this);
 	}
 
 	return *this;
 }
 
 void qdAnimationSet::resize(int sz) {
-	animations_.resize(sz);
-	static_animations_.resize(sz);
-	start_animations_.resize(sz);
-	stop_animations_.resize(sz);
+	_animations.resize(sz);
+	_static_animations.resize(sz);
+	_start_animations.resize(sz);
+	_stop_animations.resize(sz);
 	walk_sound_frequency_.resize(sz, 1);
 
 	for (int i = 0; i < size(); i ++) {
-		animations_[i].set_owner(this);
-		static_animations_[i].set_owner(this);
+		_animations[i].set_owner(this);
+		_static_animations[i].set_owner(this);
 	}
 }
 
 qdAnimationInfo *qdAnimationSet::get_animation_info(int index) {
 	if (index >= 0 && index < size())
-		return &animations_[index];
+		return &_animations[index];
 
 	return 0;
 }
@@ -123,11 +123,11 @@ float qdAnimationSet::get_index_angle(int index, int dir_count) {
 }
 
 float qdAnimationSet::get_index_angle(int direction_index) const {
-	return get_index_angle(direction_index, size()) + start_angle_;
+	return get_index_angle(direction_index, size()) + _start_angle;
 }
 
 int qdAnimationSet::get_angle_index(float direction_angle) const {
-	return get_angle_index(direction_angle - start_angle_, size());
+	return get_angle_index(direction_angle - _start_angle, size());
 }
 
 qdAnimationInfo *qdAnimationSet::get_animation_info(float direction_angle) {
@@ -137,7 +137,7 @@ qdAnimationInfo *qdAnimationSet::get_animation_info(float direction_angle) {
 
 qdAnimationInfo *qdAnimationSet::get_static_animation_info(int index) {
 	if (index >= 0 && index < size())
-		return &static_animations_[index];
+		return &_static_animations[index];
 
 	return 0;
 }
@@ -149,7 +149,7 @@ qdAnimationInfo *qdAnimationSet::get_static_animation_info(float direction_angle
 
 qdAnimationInfo *qdAnimationSet::get_start_animation_info(int index) {
 	if (index >= 0 && index < size())
-		return &start_animations_[index];
+		return &_start_animations[index];
 
 	return 0;
 }
@@ -161,7 +161,7 @@ qdAnimationInfo *qdAnimationSet::get_start_animation_info(float direction_angle)
 
 qdAnimationInfo *qdAnimationSet::get_stop_animation_info(int index) {
 	if (index >= 0 && index < size())
-		return &stop_animations_[index];
+		return &_stop_animations[index];
 
 	return 0;
 }
@@ -190,13 +190,13 @@ void qdAnimationSet::load_script(const xml::tag *p) {
 			break;
 		case QDSCR_ANIMATION_INFO:
 			if (index < size())
-				animations_[index].load_script(&*it);
+				_animations[index].load_script(&*it);
 			else if (index < size() * 2)
-				static_animations_[index - size()].load_script(&*it);
+				_static_animations[index - size()].load_script(&*it);
 			else if (index < size() * 3)
-				start_animations_[index - size() * 2].load_script(&*it);
+				_start_animations[index - size() * 2].load_script(&*it);
 			else
-				stop_animations_[index - size() * 3].load_script(&*it);
+				_stop_animations[index - size() * 3].load_script(&*it);
 
 			index ++;
 			break;
@@ -204,7 +204,7 @@ void qdAnimationSet::load_script(const xml::tag *p) {
 			turn_animation_.set_animation_name(it->data());
 			break;
 		case QDSCR_ANIMATION_SET_START_ANGLE:
-			xml::tag_buffer(*it) > start_angle_;
+			xml::tag_buffer(*it) > _start_angle;
 			break;
 		case QDSCR_OBJECT_STATE_WALK_SOUND_FREQUENCY: {
 			xml::tag_buffer buf(*it);
@@ -229,25 +229,25 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 
 	fh.writeString(Common::String::format(" size=\"%d\"", size()));
 
-	if (fabs(start_angle_) > FLT_EPS) {
-		fh.writeString(Common::String::format(" start_angle=\"%f\"", start_angle_));
+	if (fabs(_start_angle) > FLT_EPS) {
+		fh.writeString(Common::String::format(" start_angle=\"%f\"", _start_angle));
 	}
 
 	fh.writeString(">\r\n");
 
-	for (auto &it : animations_) {
+	for (auto &it : _animations) {
 		it.save_script(fh, indent + 1);
 	}
 
-	for (auto &it : static_animations_) {
+	for (auto &it : _static_animations) {
 		it.save_script(fh, indent + 1);
 	}
 
-	for (auto &it : start_animations_) {
+	for (auto &it : _start_animations) {
 		it.save_script(fh, indent + 1);
 	}
 
-	for (auto &it : stop_animations_) {
+	for (auto &it : _stop_animations) {
 		it.save_script(fh, indent + 1);
 	}
 
@@ -274,26 +274,26 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 
 bool qdAnimationSet::load_animations(const qdNamedObject *res_owner) {
 	if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
-		for (auto &it : animations_) {
+		for (auto &it : _animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->load_resource(p, res_owner);
 			}
 		}
 
-		for (auto &it : static_animations_) {
+		for (auto &it : _static_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->load_resource(p, res_owner);
 			}
 		}
 
 
-		for (auto &it : start_animations_) {
+		for (auto &it : _start_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->load_resource(p, res_owner);
 			}
 		}
 
-		for (auto &it : stop_animations_) {
+		for (auto &it : _stop_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->load_resource(p, res_owner);
 			}
@@ -310,25 +310,25 @@ bool qdAnimationSet::load_animations(const qdNamedObject *res_owner) {
 
 bool qdAnimationSet::free_animations(const qdNamedObject *res_owner) {
 	if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
-		for (auto &it : animations_) {
+		for (auto &it : _animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->release_resource(p, res_owner);
 			}
 		}
 
-		for (auto &it : static_animations_) {
+		for (auto &it : _static_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->release_resource(p, res_owner);
 			}
 		}
 
-		for (auto &it : start_animations_) {
+		for (auto &it : _start_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->release_resource(p, res_owner);
 			}
 		}
 
-		for (auto &it : stop_animations_) {
+		for (auto &it : _stop_animations) {
 			if (qdAnimation *p = it.animation()) {
 				dp->release_resource(p, res_owner);
 			}
@@ -346,22 +346,22 @@ bool qdAnimationSet::free_animations(const qdNamedObject *res_owner) {
 bool qdAnimationSet::scale_animations(float coeff_x, float coeff_y) {
 	bool res = true;
 
-	for (auto &it : animations_) {
+	for (auto &it : _animations) {
 		qdAnimation *p = it.animation();
 		if (p)
 			if (!p->scale(coeff_x, coeff_y)) res = false;
 	}
-	for (auto &it : static_animations_) {
+	for (auto &it : _static_animations) {
 		qdAnimation *p = it.animation();
 		if (p)
 			if (!p->scale(coeff_x, coeff_y)) res = false;
 	}
-	for (auto &it : start_animations_) {
+	for (auto &it : _start_animations) {
 		qdAnimation *p = it.animation();
 		if (p)
 			if (!p->scale(coeff_x, coeff_y)) res = false;
 	}
-	for (auto &it : stop_animations_) {
+	for (auto &it : _stop_animations) {
 		qdAnimation *p = it.animation();
 		if (p)
 			if (!p->scale(coeff_x, coeff_y)) res = false;
@@ -375,19 +375,19 @@ bool qdAnimationSet::scale_animations(float coeff_x, float coeff_y) {
 
 bool qdAnimationSet::register_resources(const qdNamedObject *res_owner) {
 	if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
-		for (auto &it : animations_) {
+		for (auto &it : _animations) {
 			if (qdAnimation *p = it.animation())
 				dp->register_resource(p, res_owner);
 		}
-		for (auto &it : static_animations_) {
+		for (auto &it : _static_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->register_resource(p, res_owner);
 		}
-		for (auto &it : start_animations_) {
+		for (auto &it : _start_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->register_resource(p, res_owner);
 		}
-		for (auto &it : stop_animations_) {
+		for (auto &it : _stop_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->register_resource(p, res_owner);
 		}
@@ -401,19 +401,19 @@ bool qdAnimationSet::register_resources(const qdNamedObject *res_owner) {
 
 bool qdAnimationSet::unregister_resources(const qdNamedObject *res_owner) {
 	if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
-		for (auto &it : animations_) {
+		for (auto &it : _animations) {
 			if (qdAnimation *p = it.animation())
 				dp->unregister_resource(p, res_owner);
 		}
-		for (auto &it : static_animations_) {
+		for (auto &it : _static_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->unregister_resource(p, res_owner);
 		}
-		for (auto &it : start_animations_) {
+		for (auto &it : _start_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->unregister_resource(p, res_owner);
 		}
-		for (auto &it : stop_animations_) {
+		for (auto &it : _stop_animations) {
 			if (qdAnimation *p = it.animation())
 				dp->unregister_resource(p, res_owner);
 		}

--- a/qdcore/qd_animation_set.h
+++ b/qdcore/qd_animation_set.h
@@ -71,10 +71,10 @@ public:
 
 	qdAnimation *get_turn_animation() const;
 	qdAnimationInfo *get_turn_animation_info() {
-		return &turn_animation_;
+		return &_turn_animation;
 	}
 	void set_turn_animation(const char *animation_name) {
-		turn_animation_.set_animation_name(animation_name);
+		_turn_animation.set_animation_name(animation_name);
 	}
 
 	float walk_sound_frequency(int direction_index) const;
@@ -114,10 +114,10 @@ private:
 	qdAnimationInfoVector _stop_animations;
 
 	/// анимация поворота, полный оборот начиная с направления вправо
-	qdAnimationInfo turn_animation_;
+	qdAnimationInfo _turn_animation;
 
 	//! Коэффициенты для частоты звука походки.
-	std::vector<float> walk_sound_frequency_;
+	std::vector<float> _walk_sound_frequency;
 
 	static int get_angle_index(float direction_angle, int dir_count);
 	static float get_index_angle(int index, int dir_count);

--- a/qdcore/qd_animation_set.h
+++ b/qdcore/qd_animation_set.h
@@ -44,7 +44,7 @@ public:
 	}
 
 	int size() const {
-		return animations_.size();
+		return _animations.size();
 	}
 	void resize(int sz);
 
@@ -94,10 +94,10 @@ public:
 	bool save_script(Common::WriteStream &fh, int indent = 0) const;
 
 	float start_angle() const {
-		return start_angle_;
+		return _start_angle;
 	}
 	void set_start_angle(float v) {
-		start_angle_ = v;
+		_start_angle = v;
 	}
 
 private:
@@ -106,12 +106,12 @@ private:
 	/**
 	Если нулевой - первое направление вправо.
 	*/
-	float start_angle_;
+	float _start_angle;
 
-	qdAnimationInfoVector animations_;
-	qdAnimationInfoVector static_animations_;
-	qdAnimationInfoVector start_animations_;
-	qdAnimationInfoVector stop_animations_;
+	qdAnimationInfoVector _animations;
+	qdAnimationInfoVector _static_animations;
+	qdAnimationInfoVector _start_animations;
+	qdAnimationInfoVector _stop_animations;
 
 	/// анимация поворота, полный оборот начиная с направления вправо
 	qdAnimationInfo turn_animation_;

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -32,15 +32,15 @@ namespace QDEngine {
 
 qdAnimationSetPreview::qdAnimationSetPreview(qdAnimationSet *p) :
 	graph_d_(0),
-	animation_set_(p),
+	_animation_set(p),
 	preview_mode_(VIEW_WALK_ANIMATIONS) {
-	animation_ = new qdAnimation;
+	_animation = new qdAnimation;
 
 	camera_ = new qdCamera;
 	camera_->set_focus(2000.0f);
 	camera_angle_ = 45;
 
-	start_time_ = 0;
+	_start_time = 0;
 	back_color_ = 0x000000FF;
 	grid_color_ = 0x00FF00FF;
 
@@ -48,15 +48,15 @@ qdAnimationSetPreview::qdAnimationSetPreview(qdAnimationSet *p) :
 
 	cell_size_ = 100;
 
-	personage_height_ = float(animation_->size_y());
+	_personage_height = float(_animation->size_y());
 
 	p->load_animations(NULL);
 }
 
 qdAnimationSetPreview::~qdAnimationSetPreview() {
-	animation_set_->free_animations(NULL);
+	_animation_set->free_animations(NULL);
 
-	delete animation_;
+	delete _animation;
 	delete camera_;
 }
 
@@ -66,16 +66,16 @@ void qdAnimationSetPreview::set_graph_dispatcher(grDispatcher *p) {
 }
 
 void qdAnimationSetPreview::start() {
-	start_time_ = g_system->getMillis();
+	_start_time = g_system->getMillis();
 
-	animation_->start();
+	_animation->start();
 	cell_offset_ = 0.0f;
 }
 
 void qdAnimationSetPreview::quant() {
 	int time = g_system->getMillis();
-	float tm = float(time - start_time_) / 1000.0f;
-	start_time_ = time;
+	float tm = float(time - _start_time) / 1000.0f;
+	_start_time = time;
 
 	if (tm >= 0.3f) return;
 
@@ -83,9 +83,9 @@ void qdAnimationSetPreview::quant() {
 }
 
 void qdAnimationSetPreview::quant(float tm) {
-	animation_->quant(tm);
+	_animation->quant(tm);
 
-	cell_offset_ -= personage_speed_ * tm;
+	cell_offset_ -= _personage_speed * tm;
 	while (cell_offset_ <= -float(cell_size_)) cell_offset_ += float(cell_size_);
 }
 
@@ -96,11 +96,11 @@ void qdAnimationSetPreview::redraw() {
 
 	redraw_grid();
 
-	Vect2s v = camera_->global2scr(Vect3f(0.0f, 0.0f, personage_height_ / 2.0f));
-	float scale = camera_->get_scale(Vect3f(0.0f, 0.0f, personage_height_ / 2.0f));
-	animation_->redraw(v.x, v.y, scale);
+	Vect2s v = camera_->global2scr(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
+	float scale = camera_->get_scale(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
+	_animation->redraw(v.x, v.y, scale);
 
-	Vect2s v0 = camera_->global2scr(Vect3f(0.0f, 0.0f, personage_height_));
+	Vect2s v0 = camera_->global2scr(Vect3f(0.0f, 0.0f, _personage_height));
 	Vect2s v1 = camera_->global2scr(Vect3f(0.0f, 0.0f, 0.0f));
 
 	const int rect_sz = 4;
@@ -119,34 +119,34 @@ void qdAnimationSetPreview::redraw() {
 bool qdAnimationSetPreview::set_direction(int dir) {
 	bool result = false;
 
-	animation_->clear();
-	personage_speed_ = 0.0f;
-	direction_ = dir;
+	_animation->clear();
+	_personage_speed = 0.0f;
+	_direction = dir;
 	cell_offset_ = 0.0f;
 
-	float angle = animation_set_->get_index_angle(direction_) * 180.0f / M_PI;
+	float angle = _animation_set->get_index_angle(_direction) * 180.0f / M_PI;
 	camera_->rotate_and_scale(camera_angle_, 0, angle, 1.0f, 1.0f, 1.0f);
 
 	qdAnimationInfo *p = NULL;
 	if (preview_mode_ == VIEW_WALK_ANIMATIONS)
-		p = animation_set_->get_animation_info(dir);
+		p = _animation_set->get_animation_info(dir);
 	else if (preview_mode_ == VIEW_STATIC_ANIMATIONS)
-		p = animation_set_->get_static_animation_info(dir);
+		p = _animation_set->get_static_animation_info(dir);
 	else if (preview_mode_ == VIEW_START_ANIMATIONS)
-		p = animation_set_->get_start_animation_info(dir);
+		p = _animation_set->get_start_animation_info(dir);
 	else if (preview_mode_ == VIEW_STOP_ANIMATIONS)
-		p = animation_set_->get_stop_animation_info(dir);
+		p = _animation_set->get_stop_animation_info(dir);
 
 	if (p) {
 		qdAnimation *ap = p->animation();
 		if (ap) {
-			ap->create_reference(animation_, p);
+			ap->create_reference(_animation, p);
 			result = true;
 		}
-		personage_speed_ = p->speed();
+		_personage_speed = p->speed();
 	}
 
-	animation_->start();
+	_animation->start();
 
 	return result;
 }
@@ -154,7 +154,7 @@ bool qdAnimationSetPreview::set_direction(int dir) {
 void qdAnimationSetPreview::set_cell_size(int sz) {
 	cell_size_ = sz;
 
-	animation_->start();
+	_animation->start();
 	cell_offset_ = 0.0f;
 }
 
@@ -216,7 +216,7 @@ void qdAnimationSetPreview::redraw_grid() {
 void qdAnimationSetPreview::set_camera_angle(int ang) {
 	camera_angle_ = ang;
 
-	float angle = animation_set_->get_index_angle(direction_) * 180.0f / M_PI;
+	float angle = _animation_set->get_index_angle(_direction) * 180.0f / M_PI;
 	camera_->rotate_and_scale(camera_angle_, 0, angle, 1.0f, 1.0f, 1.0f);
 }
 
@@ -229,13 +229,13 @@ void qdAnimationSetPreview::set_camera_focus(float f) {
 }
 
 bool qdAnimationSetPreview::set_phase(float phase) {
-	if (!animation_->is_empty()) {
-		if (!animation_->is_playing())
-			animation_->start();
+	if (!_animation->is_empty()) {
+		if (!_animation->is_playing())
+			_animation->start();
 
 		cell_offset_ = 0.0f;
-		animation_->set_time(0.0f);
-		quant(animation_->length() * phase);
+		_animation->set_time(0.0f);
+		quant(_animation->length() * phase);
 		return true;
 	}
 

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -31,22 +31,22 @@
 namespace QDEngine {
 
 qdAnimationSetPreview::qdAnimationSetPreview(qdAnimationSet *p) :
-	graph_d_(0),
+	_graph_d(0),
 	_animation_set(p),
-	preview_mode_(VIEW_WALK_ANIMATIONS) {
+	_preview_mode(VIEW_WALK_ANIMATIONS) {
 	_animation = new qdAnimation;
 
-	camera_ = new qdCamera;
-	camera_->set_focus(2000.0f);
-	camera_angle_ = 45;
+	_camera = new qdCamera;
+	_camera->set_focus(2000.0f);
+	_camera_angle = 45;
 
 	_start_time = 0;
-	back_color_ = 0x000000FF;
-	grid_color_ = 0x00FF00FF;
+	_back_color = 0x000000FF;
+	_grid_color = 0x00FF00FF;
 
 	set_direction(0);
 
-	cell_size_ = 100;
+	_cell_size = 100;
 
 	_personage_height = float(_animation->size_y());
 
@@ -57,11 +57,11 @@ qdAnimationSetPreview::~qdAnimationSetPreview() {
 	_animation_set->free_animations(NULL);
 
 	delete _animation;
-	delete camera_;
+	delete _camera;
 }
 
 void qdAnimationSetPreview::set_graph_dispatcher(grDispatcher *p) {
-	graph_d_ = p;
+	_graph_d = p;
 	set_screen(Vect2s(0, 0), Vect2s(p->Get_SizeX(), p->Get_SizeY()));
 }
 
@@ -69,7 +69,7 @@ void qdAnimationSetPreview::start() {
 	_start_time = g_system->getMillis();
 
 	_animation->start();
-	cell_offset_ = 0.0f;
+	_cell_offset = 0.0f;
 }
 
 void qdAnimationSetPreview::quant() {
@@ -85,32 +85,32 @@ void qdAnimationSetPreview::quant() {
 void qdAnimationSetPreview::quant(float tm) {
 	_animation->quant(tm);
 
-	cell_offset_ -= _personage_speed * tm;
-	while (cell_offset_ <= -float(cell_size_)) cell_offset_ += float(cell_size_);
+	_cell_offset -= _personage_speed * tm;
+	while (_cell_offset <= -float(_cell_size)) _cell_offset += float(_cell_size);
 }
 
 void qdAnimationSetPreview::redraw() {
-	grDispatcher *gp = grDispatcher::set_instance(graph_d_);
+	grDispatcher *gp = grDispatcher::set_instance(_graph_d);
 
-	grDispatcher::instance()->Fill(back_color_);
+	grDispatcher::instance()->Fill(_back_color);
 
 	redraw_grid();
 
-	Vect2s v = camera_->global2scr(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
-	float scale = camera_->get_scale(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
+	Vect2s v = _camera->global2scr(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
+	float scale = _camera->get_scale(Vect3f(0.0f, 0.0f, _personage_height / 2.0f));
 	_animation->redraw(v.x, v.y, scale);
 
-	Vect2s v0 = camera_->global2scr(Vect3f(0.0f, 0.0f, _personage_height));
-	Vect2s v1 = camera_->global2scr(Vect3f(0.0f, 0.0f, 0.0f));
+	Vect2s v0 = _camera->global2scr(Vect3f(0.0f, 0.0f, _personage_height));
+	Vect2s v1 = _camera->global2scr(Vect3f(0.0f, 0.0f, 0.0f));
 
 	const int rect_sz = 4;
-	grDispatcher::instance()->Rectangle(v.x - rect_sz / 2, v.y - rect_sz / 2, rect_sz, rect_sz, grid_color_, grid_color_, GR_FILLED);
+	grDispatcher::instance()->Rectangle(v.x - rect_sz / 2, v.y - rect_sz / 2, rect_sz, rect_sz, _grid_color, _grid_color, GR_FILLED);
 
 	const int line_sz = 10;
-	grDispatcher::instance()->Line(v0.x - line_sz, v0.y, v0.x + line_sz, v0.y, grid_color_);
-	grDispatcher::instance()->Line(v1.x - line_sz, v1.y, v1.x + line_sz, v1.y, grid_color_);
-	grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, grid_color_);
-	grDispatcher::instance()->Rectangle(screen_offset_.x, screen_offset_.y, screen_size_.x, screen_size_.y, grid_color_, 0, GR_OUTLINED);
+	grDispatcher::instance()->Line(v0.x - line_sz, v0.y, v0.x + line_sz, v0.y, _grid_color);
+	grDispatcher::instance()->Line(v1.x - line_sz, v1.y, v1.x + line_sz, v1.y, _grid_color);
+	grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, _grid_color);
+	grDispatcher::instance()->Rectangle(_screen_offset.x, _screen_offset.y, _screen_size.x, _screen_size.y, _grid_color, 0, GR_OUTLINED);
 	grDispatcher::instance()->Flush();
 
 	grDispatcher::set_instance(gp);
@@ -122,19 +122,19 @@ bool qdAnimationSetPreview::set_direction(int dir) {
 	_animation->clear();
 	_personage_speed = 0.0f;
 	_direction = dir;
-	cell_offset_ = 0.0f;
+	_cell_offset = 0.0f;
 
 	float angle = _animation_set->get_index_angle(_direction) * 180.0f / M_PI;
-	camera_->rotate_and_scale(camera_angle_, 0, angle, 1.0f, 1.0f, 1.0f);
+	_camera->rotate_and_scale(_camera_angle, 0, angle, 1.0f, 1.0f, 1.0f);
 
 	qdAnimationInfo *p = NULL;
-	if (preview_mode_ == VIEW_WALK_ANIMATIONS)
+	if (_preview_mode == VIEW_WALK_ANIMATIONS)
 		p = _animation_set->get_animation_info(dir);
-	else if (preview_mode_ == VIEW_STATIC_ANIMATIONS)
+	else if (_preview_mode == VIEW_STATIC_ANIMATIONS)
 		p = _animation_set->get_static_animation_info(dir);
-	else if (preview_mode_ == VIEW_START_ANIMATIONS)
+	else if (_preview_mode == VIEW_START_ANIMATIONS)
 		p = _animation_set->get_start_animation_info(dir);
-	else if (preview_mode_ == VIEW_STOP_ANIMATIONS)
+	else if (_preview_mode == VIEW_STOP_ANIMATIONS)
 		p = _animation_set->get_stop_animation_info(dir);
 
 	if (p) {
@@ -152,80 +152,80 @@ bool qdAnimationSetPreview::set_direction(int dir) {
 }
 
 void qdAnimationSetPreview::set_cell_size(int sz) {
-	cell_size_ = sz;
+	_cell_size = sz;
 
 	_animation->start();
-	cell_offset_ = 0.0f;
+	_cell_offset = 0.0f;
 }
 
 void qdAnimationSetPreview::set_screen(Vect2s offs, Vect2s size) {
-	if (!graph_d_) return;
+	if (!_graph_d) return;
 
-	screen_offset_ = offs;
-	screen_size_ = size;
+	_screen_offset = offs;
+	_screen_size = size;
 
-	camera_->set_scr_size(size.x, size.y);
-	camera_->set_scr_center(offs.x + size.x / 2, offs.y + size.y * 3 / 4);
+	_camera->set_scr_size(size.x, size.y);
+	_camera->set_scr_center(offs.x + size.x / 2, offs.y + size.y * 3 / 4);
 
-	graph_d_->SetClip(offs.x, offs.y, offs.x + size.x, offs.y + size.y);
+	_graph_d->SetClip(offs.x, offs.y, offs.x + size.x, offs.y + size.y);
 }
 
 void qdAnimationSetPreview::redraw_grid() {
 	float size = 0;
-	Vect2f p = camera_->scr2plane(screen_offset_);
+	Vect2f p = _camera->scr2plane(_screen_offset);
 	if (fabs(p.x) > size) size = fabs(p.x);
 	if (fabs(p.y) > size) size = fabs(p.y);
-	p = camera_->scr2plane(screen_offset_ + screen_size_);
+	p = _camera->scr2plane(_screen_offset + _screen_size);
 	if (fabs(p.x) > size) size = fabs(p.x);
 	if (fabs(p.y) > size) size = fabs(p.y);
-	p = camera_->scr2plane(Vect2s(screen_offset_.x + screen_size_.x, screen_offset_.y));
+	p = _camera->scr2plane(Vect2s(_screen_offset.x + _screen_size.x, _screen_offset.y));
 	if (fabs(p.x) > size) size = fabs(p.x);
 	if (fabs(p.y) > size) size = fabs(p.y);
-	p = camera_->scr2plane(Vect2s(screen_offset_.x, screen_offset_.y + screen_size_.y));
+	p = _camera->scr2plane(Vect2s(_screen_offset.x, _screen_offset.y + _screen_size.y));
 	if (fabs(p.x) > size) size = fabs(p.x);
 	if (fabs(p.y) > size) size = fabs(p.y);
 
-	int sz = round(size) + cell_size_;
-	sz -= sz % cell_size_;
-	for (int i = -sz; i <= sz; i += cell_size_) {
-		int dx = round(cell_offset_);
+	int sz = round(size) + _cell_size;
+	sz -= sz % _cell_size;
+	for (int i = -sz; i <= sz; i += _cell_size) {
+		int dx = round(_cell_offset);
 
-		Vect3f v00 = camera_->global2camera_coord(Vect3f(i + dx, -sz, 0));
-		Vect3f v10 = camera_->global2camera_coord(Vect3f(i + dx, sz, 0));
-		if (camera_->line_cutting(v00, v10)) {
-			Vect2s v0 = camera_->camera_coord2scr(v00);
-			Vect2s v1 = camera_->camera_coord2scr(v10);
-			grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, grid_color_, 0);
+		Vect3f v00 = _camera->global2camera_coord(Vect3f(i + dx, -sz, 0));
+		Vect3f v10 = _camera->global2camera_coord(Vect3f(i + dx, sz, 0));
+		if (_camera->line_cutting(v00, v10)) {
+			Vect2s v0 = _camera->camera_coord2scr(v00);
+			Vect2s v1 = _camera->camera_coord2scr(v10);
+			grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, _grid_color, 0);
 		}
 
-		v00 = camera_->global2camera_coord(Vect3f(-sz + dx, i, 0));
-		v10 = camera_->global2camera_coord(Vect3f(sz + dx, i, 0));
-		if (camera_->line_cutting(v00, v10)) {
-			Vect2s v0 = camera_->camera_coord2scr(v00);
-			Vect2s v1 = camera_->camera_coord2scr(v10);
-			grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, grid_color_, 0);
+		v00 = _camera->global2camera_coord(Vect3f(-sz + dx, i, 0));
+		v10 = _camera->global2camera_coord(Vect3f(sz + dx, i, 0));
+		if (_camera->line_cutting(v00, v10)) {
+			Vect2s v0 = _camera->camera_coord2scr(v00);
+			Vect2s v1 = _camera->camera_coord2scr(v10);
+			grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, _grid_color, 0);
 		}
 		/*
-		        v0 = camera_->global2scr(Vect3f(-sz + dx,i,0));
-		        v1 = camera_->global2scr(Vect3f(sz + dx,i,0));
-		        grDispatcher::instance()->Line(v0.x,v0.y,v1.x,v1.y,grid_color_,0);
+		        v0 = _camera->global2scr(Vect3f(-sz + dx,i,0));
+		        v1 = _camera->global2scr(Vect3f(sz + dx,i,0));
+		        grDispatcher::instance()->Line(v0.x,v0.y,v1.x,v1.y,_grid_color,0);
 		*/
 	}
 }
 
 void qdAnimationSetPreview::set_camera_angle(int ang) {
-	camera_angle_ = ang;
+	_camera_angle = ang;
 
 	float angle = _animation_set->get_index_angle(_direction) * 180.0f / M_PI;
-	camera_->rotate_and_scale(camera_angle_, 0, angle, 1.0f, 1.0f, 1.0f);
+	_camera->rotate_and_scale(_camera_angle, 0, angle, 1.0f, 1.0f, 1.0f);
 }
 
 float qdAnimationSetPreview::camera_focus() {
-	return camera_->get_focus();
+	return _camera->get_focus();
 }
 
 void qdAnimationSetPreview::set_camera_focus(float f) {
-	camera_->set_focus(f);
+	_camera->set_focus(f);
 }
 
 bool qdAnimationSetPreview::set_phase(float phase) {
@@ -233,7 +233,7 @@ bool qdAnimationSetPreview::set_phase(float phase) {
 		if (!_animation->is_playing())
 			_animation->start();
 
-		cell_offset_ = 0.0f;
+		_cell_offset = 0.0f;
 		_animation->set_time(0.0f);
 		quant(_animation->length() * phase);
 		return true;

--- a/qdcore/qd_animation_set_preview.h
+++ b/qdcore/qd_animation_set_preview.h
@@ -46,30 +46,30 @@ public:
 	~qdAnimationSetPreview();
 
 	preview_mode_t preview_mode() const {
-		return preview_mode_;
+		return _preview_mode;
 	}
 	void set_preview_mode(preview_mode_t md) {
-		preview_mode_ = md;
+		_preview_mode = md;
 	}
 
 	void set_screen(Vect2s offs, Vect2s size);
 
 	unsigned back_color() const {
-		return back_color_;
+		return _back_color;
 	}
 	void set_back_color(unsigned col) {
-		back_color_ = col;
+		_back_color = col;
 	}
 
 	unsigned grid_color() const {
-		return grid_color_;
+		return _grid_color;
 	}
 	void set_grid_color(unsigned col) {
-		grid_color_ = col;
+		_grid_color = col;
 	}
 
 	int camera_angle() const {
-		return camera_angle_;
+		return _camera_angle;
 	}
 	void set_camera_angle(int ang);
 
@@ -77,7 +77,7 @@ public:
 	void set_camera_focus(float f);
 
 	int cell_size() const {
-		return cell_size_;
+		return _cell_size;
 	}
 	void set_cell_size(int sz);
 
@@ -126,21 +126,21 @@ private:
 	qdAnimation *_animation;
 	qdAnimationSet *_animation_set;
 
-	qdCamera *camera_;
-	int camera_angle_;
+	qdCamera *_camera;
+	int _camera_angle;
 
-	grDispatcher *graph_d_;
+	grDispatcher *_graph_d;
 
-	unsigned back_color_;
-	unsigned grid_color_;
+	unsigned _back_color;
+	unsigned _grid_color;
 
-	int cell_size_;
-	float cell_offset_;
+	int _cell_size;
+	float _cell_offset;
 
-	Vect2s screen_offset_;
-	Vect2s screen_size_;
+	Vect2s _screen_offset;
+	Vect2s _screen_size;
 
-	preview_mode_t preview_mode_;
+	preview_mode_t _preview_mode;
 
 	void redraw_grid();
 };

--- a/qdcore/qd_animation_set_preview.h
+++ b/qdcore/qd_animation_set_preview.h
@@ -82,21 +82,21 @@ public:
 	void set_cell_size(int sz);
 
 	float personage_speed() const {
-		return personage_speed_;
+		return _personage_speed;
 	}
 	void set_personage_speed(float sp) {
-		personage_speed_ = sp;
+		_personage_speed = sp;
 	}
 
 	float personage_height() const {
-		return personage_height_;
+		return _personage_height;
 	}
 	void set_personage_height(float h) {
-		personage_height_ = h;
+		_personage_height = h;
 	}
 
 	int direction() const {
-		return direction_;
+		return _direction;
 	}
 	bool set_direction(int dir);
 
@@ -111,20 +111,20 @@ public:
 	void redraw();
 
 	const qdAnimation *cur_animation() const {
-		return animation_;
+		return _animation;
 	}
 
 private:
-	int start_time_;
+	int _start_time;
 
-	int direction_;
+	int _direction;
 	//float speed_;
 
-	float personage_speed_;
-	float personage_height_;
+	float _personage_speed;
+	float _personage_height;
 
-	qdAnimation *animation_;
-	qdAnimationSet *animation_set_;
+	qdAnimation *_animation;
+	qdAnimationSet *_animation_set;
 
 	qdCamera *camera_;
 	int camera_angle_;

--- a/qdcore/qd_camera_mode.cpp
+++ b/qdcore/qd_camera_mode.cpp
@@ -31,12 +31,12 @@
 
 namespace QDEngine {
 
-qdCameraMode::qdCameraMode() : camera_mode_(MODE_UNASSIGNED),
-	work_time_(0.0f),
-	scrolling_speed_(100.0f),
-	scrolling_distance_(100),
-	smooth_switch_(false),
-	center_offset_(0, 0) {
+qdCameraMode::qdCameraMode() : _camera_mode(MODE_UNASSIGNED),
+	_work_time(0.0f),
+	_scrolling_speed(100.0f),
+	_scrolling_distance(100),
+	_smooth_switch(false),
+	_center_offset(0, 0) {
 }
 
 bool qdCameraMode::load_script(const xml::tag *p) {
@@ -57,10 +57,10 @@ bool qdCameraMode::load_script(const xml::tag *p) {
 			set_scrolling_distance(buf.get_int());
 			break;
 		case QDSCR_CAMERA_SMOOTH_SWITCH:
-			smooth_switch_ = (buf.get_int()) ? true : false;
+			_smooth_switch = (buf.get_int()) ? true : false;
 			break;
 		case QDSCR_CAMERA_SCREEN_CENTER:
-			buf > center_offset_.x > center_offset_.y;
+			buf > _center_offset.x > _center_offset.y;
 			break;
 		}
 	}
@@ -74,11 +74,11 @@ bool qdCameraMode::save_script(Common::WriteStream &fh, int indent) const {
 	}
 
 	fh.writeString(Common::String::format("<camera_mode type=\"%d\"", (int)camera_mode()));
-	fh.writeString(Common::String::format(" scrolling_speed=\"%f\"", scrolling_speed_));
-	fh.writeString(Common::String::format(" scrolling_dist=\"%d\"", scrolling_distance_));
+	fh.writeString(Common::String::format(" scrolling_speed=\"%f\"", _scrolling_speed));
+	fh.writeString(Common::String::format(" scrolling_dist=\"%d\"", _scrolling_distance));
 
-	if (center_offset_.x || center_offset_.y) {
-		fh.writeString(Common::String::format(" camera_screen_center=\"%d %d\"", center_offset_.x, center_offset_.y));
+	if (_center_offset.x || _center_offset.y) {
+		fh.writeString(Common::String::format(" camera_screen_center=\"%d %d\"", _center_offset.x, _center_offset.y));
 	}
 
 	if (has_work_time()) {
@@ -98,14 +98,14 @@ bool qdCameraMode::load_data(Common::SeekableReadStream &fh, int save_version) {
 	debugC(4, kDebugSave, "    qdCameraMode::load_data(): before %ld", fh.pos());
 	int mode;
 	mode = fh.readSint32LE();
-	work_time_ = fh.readFloatLE();
-	scrolling_speed_ = fh.readFloatLE();
-	scrolling_distance_ = fh.readSint32LE();
-	center_offset_.x = fh.readSint32LE();
-	center_offset_.y = fh.readSint32LE();
+	_work_time = fh.readFloatLE();
+	_scrolling_speed = fh.readFloatLE();
+	_scrolling_distance = fh.readSint32LE();
+	_center_offset.x = fh.readSint32LE();
+	_center_offset.y = fh.readSint32LE();
 
 	char switch_flag = fh.readByte();
-	smooth_switch_ = (switch_flag) ? true : false;
+	_smooth_switch = (switch_flag) ? true : false;
 	debugC(4, kDebugSave, "    qdCameraMode::load_data(): after %ld", fh.pos());
 
 	return true;
@@ -114,15 +114,15 @@ bool qdCameraMode::load_data(Common::SeekableReadStream &fh, int save_version) {
 bool qdCameraMode::save_data(Common::WriteStream &fh) const {
 	debugC(4, kDebugSave, "    qdCameraMode::save_data(): before %ld", fh.pos());
 
-	fh.writeSint32LE((int)camera_mode_);
-	fh.writeFloatLE(work_time_);
-	fh.writeFloatLE(scrolling_speed_);
-	fh.writeSint32LE(scrolling_distance_);
-	fh.writeSint32LE(center_offset_.x);
-	fh.writeSint32LE(center_offset_.y);
+	fh.writeSint32LE((int)_camera_mode);
+	fh.writeFloatLE(_work_time);
+	fh.writeFloatLE(_scrolling_speed);
+	fh.writeSint32LE(_scrolling_distance);
+	fh.writeSint32LE(_center_offset.x);
+	fh.writeSint32LE(_center_offset.y);
 
 
-	if (smooth_switch_) {
+	if (_smooth_switch) {
 		fh.writeByte(1);
 	} else {
 		fh.writeByte(0);

--- a/qdcore/qd_camera_mode.h
+++ b/qdcore/qd_camera_mode.h
@@ -56,48 +56,48 @@ public:
 	};
 
 	void set_camera_mode(camera_mode_t mode) {
-		camera_mode_ = mode;
+		_camera_mode = mode;
 	}
 	camera_mode_t camera_mode() const {
-		return camera_mode_;
+		return _camera_mode;
 	}
 
 	void set_work_time(float tm) {
-		work_time_ = tm;
+		_work_time = tm;
 	}
 	float work_time() const {
-		return work_time_;
+		return _work_time;
 	}
 	bool has_work_time() const {
-		return work_time_ > 0.001f;
+		return _work_time > 0.001f;
 	}
 
 	void set_scrolling_speed(float v) {
-		scrolling_speed_ = v;
+		_scrolling_speed = v;
 	}
 	float scrolling_speed() const {
-		return scrolling_speed_;
+		return _scrolling_speed;
 	}
 
 	void set_scrolling_distance(int dist) {
-		scrolling_distance_ = dist;
+		_scrolling_distance = dist;
 	}
 	int scrolling_distance() const {
-		return scrolling_distance_;
+		return _scrolling_distance;
 	}
 
 	bool smooth_switch() const {
-		return smooth_switch_;
+		return _smooth_switch;
 	}
 	void set_smooth_switch(bool v) {
-		smooth_switch_ = v;
+		_smooth_switch = v;
 	}
 
 	const Vect2i &center_offset() const {
-		return center_offset_;
+		return _center_offset;
 	}
 	void set_center_offset(const Vect2i &offs) {
-		center_offset_ = offs;
+		_center_offset = offs;
 	}
 
 	bool load_script(const xml::tag *p);
@@ -111,7 +111,7 @@ public:
 private:
 
 	//! Идентификатор режима.
-	camera_mode_t camera_mode_;
+	camera_mode_t _camera_mode;
 
 	//! Время работы режима (в секундах).
 	/**
@@ -121,10 +121,10 @@ private:
 	Если это время нулевое, то сменить режим можно будет
 	только в принудительном порядке из триггера.
 	*/
-	float work_time_;
+	float _work_time;
 
 	//! Скорость, с которой камера скроллируется (в пикселах в секунду).
-	float scrolling_speed_;
+	float _scrolling_speed;
 
 	//! Расстояние от центра объекта до края экрана, при котором включается скроллинг.
 	/**
@@ -133,17 +133,17 @@ private:
 
 	Задается в пикселах.
 	*/
-	int scrolling_distance_;
+	int _scrolling_distance;
 
 	//! Смещение центра экрана в пикселах.
 	/**
 	Позволяет задавать режим, когда камера, центруясь на объекте,
 	держит его в определенной точке экрана.
 	*/
-	Vect2i center_offset_;
+	Vect2i _center_offset;
 
 	//! Плавное переключение в режим, если true.
-	bool smooth_switch_;
+	bool _smooth_switch;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_music_track.cpp
+++ b/qdcore/qd_music_track.cpp
@@ -28,13 +28,13 @@
 
 namespace QDEngine {
 
-qdMusicTrack::qdMusicTrack() : volume_(256) {
+qdMusicTrack::qdMusicTrack() : _volume(256) {
 	toggle_cycle(true);
 }
 
 qdMusicTrack::qdMusicTrack(const qdMusicTrack &trk) : qdConditionalObject(trk),
-	file_name_(trk.file_name_),
-	volume_(trk.volume_) {
+	_file_name(trk._file_name),
+	_volume(trk._volume) {
 }
 
 qdMusicTrack::~qdMusicTrack() {
@@ -45,8 +45,8 @@ qdMusicTrack &qdMusicTrack::operator = (const qdMusicTrack &trk) {
 
 	*static_cast<qdConditionalObject *>(this) = trk;
 
-	file_name_ = trk.file_name_;
-	volume_ = trk.volume_;
+	_file_name = trk._file_name;
+	_volume = trk._volume;
 
 	return *this;
 }
@@ -92,16 +92,16 @@ bool qdMusicTrack::save_script(Common::WriteStream &fh, int indent) const {
 
 	fh.writeString(Common::String::format(" flags=\"%d\"", flags()));
 
-	if (!file_name_.empty()) {
-		fh.writeString(Common::String::format(" file=\"%s\"", qdscr_XML_string(file_name_.c_str())));
+	if (!_file_name.empty()) {
+		fh.writeString(Common::String::format(" file=\"%s\"", qdscr_XML_string(_file_name.c_str())));
 	}
 
 	if (is_cycled()) {
 		fh.writeString(" cycled=\"1\"");
 	}
 
-	if (volume_ != 256) {
-		fh.writeString(Common::String::format(" volume=\"%d\"", volume_));
+	if (_volume != 256) {
+		fh.writeString(Common::String::format(" volume=\"%d\"", _volume));
 	}
 
 	if (has_conditions()) {

--- a/qdcore/qd_music_track.h
+++ b/qdcore/qd_music_track.h
@@ -53,13 +53,13 @@ public:
 	}
 
 	void set_file_name(const char *fname) {
-		file_name_ = fname;
+		_file_name = fname;
 	}
 	const char *file_name() const {
-		return file_name_.c_str();
+		return _file_name.c_str();
 	}
 	bool has_file_name() const {
-		return !file_name_.empty();
+		return !_file_name.empty();
 	}
 
 	void toggle_cycle(bool v) {
@@ -71,12 +71,12 @@ public:
 	}
 
 	int volume() const {
-		return volume_;
+		return _volume;
 	}
 	void set_volume(int vol) {
 		if (vol < 0) vol = 0;
 		else if (vol > 256) vol = 256;
-		volume_ = vol;
+		_volume = vol;
 	}
 
 	//! Чтение данных из скрипта.
@@ -89,10 +89,10 @@ public:
 private:
 
 	//! Имя mp+ файла.
-	std::string file_name_;
+	std::string _file_name;
 
 	//! Громкость, [0, 256].
-	int volume_;
+	int _volume;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_named_object.cpp
+++ b/qdcore/qd_named_object.cpp
@@ -30,21 +30,21 @@
 namespace QDEngine {
 
 
-qdNamedObject::qdNamedObject() : owner_(0),
-	trigger_reference_count_(0),
+qdNamedObject::qdNamedObject() : _owner(0),
+	_trigger_reference_count(0),
 #ifdef _QUEST_EDITOR
 	ref_owner_(0),
 #endif
-	flags_(0) {
+	_flags(0) {
 }
 
 qdNamedObject::qdNamedObject(const qdNamedObject &obj) : qdNamedObjectBase(obj),
-	owner_(obj.owner_),
+	_owner(obj._owner),
 #ifdef _QUEST_EDITOR
 	ref_owner_(obj.ref_owner_),
 #endif
-	flags_(obj.flags_),
-	trigger_reference_count_(0) {
+	_flags(obj._flags),
+	_trigger_reference_count(0) {
 }
 
 qdNamedObject::~qdNamedObject() {
@@ -55,8 +55,8 @@ qdNamedObject &qdNamedObject::operator = (const qdNamedObject &obj) {
 
 	*static_cast<qdNamedObjectBase *>(this) = obj;
 
-	flags_ = obj.flags_;
-	owner_ = obj.owner_;
+	_flags = obj._flags;
+	_owner = obj._owner;
 #ifdef _QUEST_EDITOR
 	ref_owner_ = obj.ref_owner_;
 #endif
@@ -75,12 +75,12 @@ qdNamedObject *qdNamedObject::owner(qdNamedObjectType tp) const {
 }
 
 bool qdNamedObject::load_data(Common::SeekableReadStream &fh, int saveVersion) {
-	flags_ = fh.readSint32LE();
+	_flags = fh.readSint32LE();
 	return true;
 }
 
 bool qdNamedObject::save_data(Common::WriteStream &fh) const {
-	fh.writeSint32LE(flags_);
+	fh.writeSint32LE(_flags);
 	return true;
 }
 

--- a/qdcore/qd_named_object.cpp
+++ b/qdcore/qd_named_object.cpp
@@ -32,17 +32,11 @@ namespace QDEngine {
 
 qdNamedObject::qdNamedObject() : _owner(0),
 	_trigger_reference_count(0),
-#ifdef _QUEST_EDITOR
-	ref_owner_(0),
-#endif
 	_flags(0) {
 }
 
 qdNamedObject::qdNamedObject(const qdNamedObject &obj) : qdNamedObjectBase(obj),
 	_owner(obj._owner),
-#ifdef _QUEST_EDITOR
-	ref_owner_(obj.ref_owner_),
-#endif
 	_flags(obj._flags),
 	_trigger_reference_count(0) {
 }
@@ -57,9 +51,6 @@ qdNamedObject &qdNamedObject::operator = (const qdNamedObject &obj) {
 
 	_flags = obj._flags;
 	_owner = obj._owner;
-#ifdef _QUEST_EDITOR
-	ref_owner_ = obj.ref_owner_;
-#endif
 	return *this;
 }
 

--- a/qdcore/qd_named_object.h
+++ b/qdcore/qd_named_object.h
@@ -159,9 +159,6 @@ private:
 
 	//! Владелец объекта.
 	mutable qdNamedObject *_owner;
-#ifdef _QUEST_EDITOR
-	mutable qdNamedObject *ref__owner;
-#endif
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_named_object.h
+++ b/qdcore/qd_named_object.h
@@ -77,7 +77,7 @@ public:
 
 	//! Возвращает владельца объекта.
 	qdNamedObject *owner() const {
-		return owner_;
+		return _owner;
 	}
 	//! Возвращает владельца объекта, тип которого tp.
 	qdNamedObject *owner(qdNamedObjectType tp) const;
@@ -85,40 +85,40 @@ public:
 #ifndef _QUEST_EDITOR
 	//! Устанавливает владельца объекта.
 	void set_owner(qdNamedObject *p) {
-		owner_ = p;
+		_owner = p;
 	}
 #else
 	qdNamedObject *ref_owner() const {
-		return ref_owner_;
+		return ref__owner;
 	}
 	void set_ref_owner(qdNamedObject *p) {
-		ref_owner_ = p;
+		ref__owner = p;
 	}
 	void set_owner(qdNamedObject *p) {
-		owner_ = ref_owner_ = p;
+		_owner = ref__owner = p;
 	}
 #endif
 
 	//! Устанавливает флаг.
 	void set_flag(int fl) {
-		flags_ |= fl;
+		_flags |= fl;
 	}
 	//! Скидывает флаг.
 	void drop_flag(int fl) {
-		flags_ &= ~fl;
+		_flags &= ~fl;
 	}
 	//! Возвращает true, если установлен флаг fl.
 	bool check_flag(int fl) const {
-		if (flags_ & fl) return true;
+		if (_flags & fl) return true;
 		return false;
 	}
 	//! Очищает флаги.
 	void clear_flags() {
-		flags_ = 0;
+		_flags = 0;
 	}
 	//! Возвращает значение флагов объекта.
 	int flags() const {
-		return flags_;
+		return _flags;
 	}
 
 	//! Возвращает тип объекта.
@@ -132,19 +132,19 @@ public:
 
 	//! Добавляет ссылку из триггеров на объект.
 	void add_trigger_reference() {
-		trigger_reference_count_++;
+		_trigger_reference_count++;
 	}
 	//! Удаляет ссылку из триггеров на объект.
 	void remove_trigger_reference() {
-		if (trigger_reference_count_) trigger_reference_count_--;
+		if (_trigger_reference_count) _trigger_reference_count--;
 	}
 	//! Очищает счётчик ссылок из триггеров на объект.
 	void clear_trigger_references() {
-		trigger_reference_count_ = 0;
+		_trigger_reference_count = 0;
 	}
 	//! Возвращает true, если на объект есть ссылки из триггеров.
 	bool is_in_triggers() const {
-		return (trigger_reference_count_ > 0);
+		return (_trigger_reference_count > 0);
 	}
 
 	Common::String toString() const;
@@ -152,15 +152,15 @@ public:
 private:
 
 	//! Некие свойства объекта.
-	int flags_;
+	int _flags;
 
 	//! Количество ссылок на объект из триггеров.
-	int trigger_reference_count_;
+	int _trigger_reference_count;
 
 	//! Владелец объекта.
-	mutable qdNamedObject *owner_;
+	mutable qdNamedObject *_owner;
 #ifdef _QUEST_EDITOR
-	mutable qdNamedObject *ref_owner_;
+	mutable qdNamedObject *ref__owner;
 #endif
 };
 

--- a/qdcore/qd_named_object_base.cpp
+++ b/qdcore/qd_named_object_base.cpp
@@ -27,7 +27,7 @@ namespace QDEngine {
 qdNamedObjectBase::qdNamedObjectBase() {
 }
 
-qdNamedObjectBase::qdNamedObjectBase(const qdNamedObjectBase &obj) : name_(obj.name_) {
+qdNamedObjectBase::qdNamedObjectBase(const qdNamedObjectBase &obj) : _name(obj._name) {
 }
 
 qdNamedObjectBase::~qdNamedObjectBase() {
@@ -36,7 +36,7 @@ qdNamedObjectBase::~qdNamedObjectBase() {
 qdNamedObjectBase &qdNamedObjectBase::operator = (const qdNamedObjectBase &obj) {
 	if (this == &obj) return *this;
 
-	name_ = obj.name_;
+	_name = obj._name;
 
 	return *this;
 }

--- a/qdcore/qd_named_object_base.h
+++ b/qdcore/qd_named_object_base.h
@@ -36,19 +36,19 @@ public:
 
 	//! Возвращает имя объекта.
 	const char *name() const {
-		if (!name_.empty()) return name_.c_str();
+		if (!_name.empty()) return _name.c_str();
 		return NULL;
 	}
 	//! Устанавливает имя объекта.
 	void set_name(const char *p) {
-		if (p) name_ = p;
-		else name_.clear();
+		if (p) _name = p;
+		else _name.clear();
 	}
 
 private:
 
 	//! Имя объекта.
-	std::string name_;
+	std::string _name;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_named_object_indexer.cpp
+++ b/qdcore/qd_named_object_indexer.cpp
@@ -43,9 +43,9 @@ qdNamedObjectIndexer &qdNamedObjectIndexer::instance() {
 
 bool qdNamedObjectIndexer::qdNamedObjectReferenceLink::resolve() {
 	if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
-		object_ = dp->get_named_object(&reference_);
-		if (!object_) {
-			debugC(3, kDebugLog, "qdNamedObjectReferenceLink::resolve() failed\n%s", reference_.toString().c_str());
+		_object = dp->get_named_object(&_reference);
+		if (!_object) {
+			debugC(3, kDebugLog, "qdNamedObjectReferenceLink::resolve() failed\n%s", _reference.toString().c_str());
 		} else
 			return true;
 	}
@@ -54,20 +54,20 @@ bool qdNamedObjectIndexer::qdNamedObjectReferenceLink::resolve() {
 }
 
 qdNamedObjectReference &qdNamedObjectIndexer::add_reference(qdNamedObject *&p) {
-	links_.push_back(qdNamedObjectReferenceLink(p));
-	return links_.back().reference();
+	_links.push_back(qdNamedObjectReferenceLink(p));
+	return _links.back().reference();
 }
 
 void qdNamedObjectIndexer::resolve_references() {
-	for (link_container_t::iterator it = links_.begin(); it != links_.end(); ++it)
+	for (link_container_t::iterator it = _links.begin(); it != _links.end(); ++it)
 		it->resolve();
 }
 
 void qdNamedObjectIndexer::clear() {
 #ifdef _QD_DEBUG_ENABLE_
-	debugC(3, kDebugLog, "qdNamedObjectIndexer::links count - %d", links_.size());
+	debugC(3, kDebugLog, "qdNamedObjectIndexer::links count - %d", _links.size());
 #endif
 
-	links_.clear();
+	_links.clear();
 }
 } // namespace QDEngine

--- a/qdcore/qd_named_object_indexer.h
+++ b/qdcore/qd_named_object_indexer.h
@@ -43,23 +43,23 @@ private:
 
 	class qdNamedObjectReferenceLink {
 	public:
-		qdNamedObjectReferenceLink(qdNamedObject *&p) : object_(p) { }
+		qdNamedObjectReferenceLink(qdNamedObject *&p) : _object(p) { }
 		~qdNamedObjectReferenceLink() { }
 
 		bool resolve();
 
 		qdNamedObjectReference &reference() {
-			return reference_;
+			return _reference;
 		}
 
 	private:
 
-		qdNamedObjectReference reference_;
-		qdNamedObject *&object_;
+		qdNamedObjectReference _reference;
+		qdNamedObject *&_object;
 	};
 
 	typedef std::list<qdNamedObjectReferenceLink> link_container_t;
-	link_container_t links_;
+	link_container_t _links;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_named_object_reference.cpp
+++ b/qdcore/qd_named_object_reference.cpp
@@ -32,33 +32,33 @@
 
 namespace QDEngine {
 
-int qdNamedObjectReference::objects_counter_ = 0;
+int qdNamedObjectReference::_objects_counter = 0;
 
 qdNamedObjectReference::qdNamedObjectReference() {
-	objects_counter_++;
+	_objects_counter++;
 }
 
 qdNamedObjectReference::qdNamedObjectReference(int levels, const int *types, const char *const *names) {
-	object_types_.reserve(levels);
-	object_names_.reserve(levels);
+	_object_types.reserve(levels);
+	_object_names.reserve(levels);
 
 	for (int i = 0; i < num_levels(); i ++) {
-		object_names_.push_back(names[i]);
-		object_types_.push_back(types[i]);
+		_object_names.push_back(names[i]);
+		_object_types.push_back(types[i]);
 	}
 
-	objects_counter_++;
+	_objects_counter++;
 }
 
-qdNamedObjectReference::qdNamedObjectReference(const qdNamedObjectReference &ref) : object_types_(ref.object_types_),
-	object_names_(ref.object_names_) {
-	objects_counter_++;
+qdNamedObjectReference::qdNamedObjectReference(const qdNamedObjectReference &ref) : _object_types(ref._object_types),
+	_object_names(ref._object_names) {
+	_objects_counter++;
 }
 
 qdNamedObjectReference::qdNamedObjectReference(const qdNamedObject *p) {
 	init(p);
 
-	objects_counter_++;
+	_objects_counter++;
 }
 
 qdNamedObjectReference::~qdNamedObjectReference() {
@@ -67,8 +67,8 @@ qdNamedObjectReference::~qdNamedObjectReference() {
 qdNamedObjectReference &qdNamedObjectReference::operator = (const qdNamedObjectReference &ref) {
 	if (this == &ref) return *this;
 
-	object_types_ = ref.object_types_;
-	object_names_ = ref.object_names_;
+	_object_types = ref._object_types;
+	_object_names = ref._object_names;
 
 	return *this;
 }
@@ -88,8 +88,8 @@ bool qdNamedObjectReference::init(const qdNamedObject *p) {
 		num_levels ++;
 	}
 
-	object_types_.reserve(num_levels);
-	object_names_.reserve(num_levels);
+	_object_types.reserve(num_levels);
+	_object_names.reserve(num_levels);
 
 	for (int i = 0; i < num_levels; i ++) {
 		obj = p;
@@ -101,8 +101,8 @@ bool qdNamedObjectReference::init(const qdNamedObject *p) {
 #endif
 		}
 		if (obj->name()) {
-			object_names_.push_back(obj->name());
-			object_types_.push_back(obj->named_object_type());
+			_object_names.push_back(obj->name());
+			_object_types.push_back(obj->named_object_type());
 		}
 	}
 
@@ -114,20 +114,20 @@ void qdNamedObjectReference::load_script(const xml::tag *p) {
 		xml::tag_buffer buf(*it);
 		switch (it->ID()) {
 		case QDSCR_SIZE:
-			object_types_.reserve(xml::tag_buffer(*it).get_int());
-			object_names_.reserve(xml::tag_buffer(*it).get_int());
+			_object_types.reserve(xml::tag_buffer(*it).get_int());
+			_object_names.reserve(xml::tag_buffer(*it).get_int());
 			break;
 		case QDSCR_NAME:
-			object_names_.push_back(it->data());
+			_object_names.push_back(it->data());
 			break;
 		case QDSCR_TYPE:
-			object_types_.push_back(xml::tag_buffer(*it).get_int());
+			_object_types.push_back(xml::tag_buffer(*it).get_int());
 			break;
 		case QDSCR_NAMED_OBJECT_TYPES:
-			object_types_.resize(it->data_size());
-			object_names_.reserve(it->data_size());
+			_object_types.resize(it->data_size());
+			_object_names.reserve(it->data_size());
 			for (int i = 0; i < it->data_size(); i++)
-				object_types_[i] = buf.get_int();
+				_object_types[i] = buf.get_int();
 			break;
 		}
 	}
@@ -141,7 +141,7 @@ bool qdNamedObjectReference::save_script(Common::WriteStream &fh, int indent) co
 
 	fh.writeString(Common::String::format(" types=\"%d", num_levels()));
 	for (int i = 0; i < num_levels(); i++) {
-		fh.writeString(Common::String::format(" %d", object_types_[i]));
+		fh.writeString(Common::String::format(" %d", _object_types[i]));
 	}
 	fh.writeString("\"");
 	fh.writeString(">\r\n");
@@ -150,7 +150,7 @@ bool qdNamedObjectReference::save_script(Common::WriteStream &fh, int indent) co
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<name>%s</name>\r\n", qdscr_XML_string(object_names_[j].c_str())));
+		fh.writeString(Common::String::format("<name>%s</name>\r\n", qdscr_XML_string(_object_names[j].c_str())));
 	}
 
 	for (int i = 0; i < indent; i++) {
@@ -165,8 +165,8 @@ bool qdNamedObjectReference::load_data(Common::SeekableReadStream &fh, int versi
 	debugC(5, kDebugSave, "      qdNamedObjectReference::load_data before: %ld", fh.pos());
 	int nlevels = fh.readSint32LE();
 
-	object_types_.resize(nlevels);
-	object_names_.resize(nlevels);
+	_object_types.resize(nlevels);
+	_object_names.resize(nlevels);
 
 	Common::String str;
 
@@ -174,8 +174,8 @@ bool qdNamedObjectReference::load_data(Common::SeekableReadStream &fh, int versi
 		int32 type = fh.readSint32LE();
 		int32 nameLen = fh.readUint32LE();
 		str = fh.readString('\0', nameLen);
-		object_types_[i] = type;
-		object_names_[i] = str.c_str();
+		_object_types[i] = type;
+		_object_names[i] = str.c_str();
 	}
 
 	debugC(5, kDebugSave, "      qdNamedObjectReference::load_data after: %ld", fh.pos());
@@ -187,9 +187,9 @@ bool qdNamedObjectReference::save_data(Common::WriteStream &fh) const {
 	fh.writeSint32LE(num_levels());
 
 	for (int i = 0; i < num_levels(); i ++) {
-		fh.writeSint32LE(object_types_[i]);
-		fh.writeUint32LE(object_names_[i].size());
-		fh.writeString(object_names_[i].c_str());
+		fh.writeSint32LE(_object_types[i]);
+		fh.writeUint32LE(_object_names[i].size());
+		fh.writeString(_object_names[i].c_str());
 	}
 
 	debugC(5, kDebugSave, "      qdNamedObjectReference::save_data after: %ld", fh.pos());

--- a/qdcore/qd_named_object_reference.h
+++ b/qdcore/qd_named_object_reference.h
@@ -42,23 +42,23 @@ public:
 	qdNamedObjectReference &operator = (const qdNamedObjectReference &ref);
 
 	int num_levels()            const {
-		return object_types_.size();
+		return _object_types.size();
 	}
 	int object_type(int level = 0)      const {
-		return object_types_[level];
+		return _object_types[level];
 	}
 	const char *object_name(int level = 0)  const {
-		return object_names_[level].c_str();
+		return _object_names[level].c_str();
 	}
 	bool is_empty()             const {
-		return object_types_.empty();
+		return _object_types.empty();
 	}
 
 	bool init(const qdNamedObject *p);
 
 	void clear() {
-		object_types_.clear();
-		object_names_.clear();
+		_object_types.clear();
+		_object_names.clear();
 	}
 
 	void load_script(const xml::tag *p);
@@ -75,9 +75,9 @@ public:
 
 private:
 
-	std::vector<int> object_types_;
-	std::vector<std::string> object_names_;
-	static int objects_counter_;
+	std::vector<int> _object_types;
+	std::vector<std::string> _object_names;
+	static int _objects_counter;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_resource.cpp
+++ b/qdcore/qd_resource.cpp
@@ -64,17 +64,17 @@ qdResource::file_format_t qdResource::file_format(const char *file_name) {
 }
 
 #ifdef __QD_DEBUG_ENABLE__
-qdResourceInfo::qdResourceInfo(const qdResource *res, const qdNamedObject *owner) : resource_(res), data_size_(0), resource_owner_(owner) {
-	if (resource_)
-		data_size_ = resource_->resource_data_size();
+qdResourceInfo::qdResourceInfo(const qdResource *res, const qdNamedObject *owner) : _resource(res), _data_size(0), _resource_owner(owner) {
+	if (_resource)
+		_data_size = _resource->resource_data_size();
 }
 
 qdResourceInfo::~qdResourceInfo() {
 }
 
 qdResource::file_format_t qdResourceInfo::file_format() const {
-	if (resource_)
-		return qdResource::file_format(resource_->resource_file());
+	if (_resource)
+		return qdResource::file_format(_resource->resource_file());
 
 	return qdResource::RES_UNKNOWN;
 }
@@ -82,4 +82,3 @@ qdResource::file_format_t qdResourceInfo::file_format() const {
 #endif
 
 } // namespace QDEngine
-

--- a/qdcore/qd_resource.h
+++ b/qdcore/qd_resource.h
@@ -91,33 +91,33 @@ private:
 class qdResourceInfo {
 public:
 	qdResourceInfo(const qdResource *res = NULL, const qdNamedObject *owner = NULL);
-	qdResourceInfo(const qdResourceInfo &inf) : resource_(inf.resource_), data_size_(inf.data_size_), resource_owner_(inf.resource_owner_) { }
+	qdResourceInfo(const qdResourceInfo &inf) : _resource(inf._resource), _data_size(inf._data_size), _resource_owner(inf._resource_owner) { }
 	~qdResourceInfo();
 
 	qdResourceInfo &operator = (const qdResourceInfo &inf) {
 		if (this == &inf) return *this;
 
-		resource_ = inf.resource_;
-		resource_owner_ = inf.resource_owner_;
-		data_size_ = inf.data_size_;
+		_resource = inf._resource;
+		_resource_owner = inf._resource_owner;
+		_data_size = inf._data_size;
 
 		return *this;
 	}
 
 	bool operator < (const qdResourceInfo &inf) const {
-		return data_size_ < inf.data_size_;
+		return _data_size < inf._data_size;
 	}
 
 	unsigned data_size() const {
-		return data_size_;
+		return _data_size;
 	}
 
 	qdResource::file_format_t file_format() const;
 
 private:
-	unsigned data_size_;
-	const qdResource *resource_;
-	const qdNamedObject *resource_owner_;
+	unsigned _data_size;
+	const qdResource *_resource;
+	const qdNamedObject *_resource_owner;
 };
 
 typedef std::vector<qdResourceInfo> qdResourceInfoContainer;

--- a/qdcore/qd_scale_info.cpp
+++ b/qdcore/qd_scale_info.cpp
@@ -28,7 +28,7 @@
 namespace QDEngine {
 
 qdScaleInfo::qdScaleInfo(const qdScaleInfo &sc) : qdNamedObject(sc),
-	scale_(sc.scale_) {
+	_scale(sc._scale) {
 }
 
 void qdScaleInfo::load_script(const xml::tag *p) {
@@ -38,7 +38,7 @@ void qdScaleInfo::load_script(const xml::tag *p) {
 			set_name(it->data());
 			break;
 		case QDSCR_SCALE:
-			xml::tag_buffer(*it) > scale_;
+			xml::tag_buffer(*it) > _scale;
 			break;
 		}
 	}

--- a/qdcore/qd_scale_info.h
+++ b/qdcore/qd_scale_info.h
@@ -30,7 +30,7 @@ namespace QDEngine {
 
 class qdScaleInfo : public qdNamedObject {
 public:
-	qdScaleInfo() : scale_(1.0f) { }
+	qdScaleInfo() : _scale(1.0f) { }
 	qdScaleInfo(const qdScaleInfo &sc);
 	~qdScaleInfo() { }
 
@@ -39,10 +39,10 @@ public:
 	}
 
 	float scale() const {
-		return scale_;
+		return _scale;
 	}
 	void set_scale(float sc) {
-		scale_ = sc;
+		_scale = sc;
 	}
 
 	void load_script(const xml::tag *p);
@@ -50,7 +50,7 @@ public:
 
 private:
 
-	float scale_;
+	float _scale;
 };
 
 typedef std::list<qdScaleInfo *> qdScaleInfoList;

--- a/qdcore/qd_screen_text.cpp
+++ b/qdcore/qd_screen_text.cpp
@@ -34,16 +34,16 @@
 
 namespace QDEngine {
 
-qdScreenTextFormat qdScreenTextFormat::default_format_;
-qdScreenTextFormat qdScreenTextFormat::global_text_format_;
-qdScreenTextFormat qdScreenTextFormat::global_topic_format_;
+qdScreenTextFormat qdScreenTextFormat::_default_format;
+qdScreenTextFormat qdScreenTextFormat::_global_text_format;
+qdScreenTextFormat qdScreenTextFormat::_global_topic_format;
 
-qdScreenTextFormat::qdScreenTextFormat() : arrangement_(ARRANGE_VERTICAL),
-	alignment_(ALIGN_LEFT),
-	color_(0xFFFFFF),
-	hover_color_(0xFFFFFF),
-	font_type_(QD_FONT_TYPE_NONE),
-	global_depend_(true) {
+qdScreenTextFormat::qdScreenTextFormat() : _arrangement(ARRANGE_VERTICAL),
+	_alignment(ALIGN_LEFT),
+	_color(0xFFFFFF),
+	_hover_color(0xFFFFFF),
+	_font_type(QD_FONT_TYPE_NONE),
+	_global_depend(true) {
 }
 
 bool qdScreenTextFormat::load_script(const xml::tag *p) {
@@ -66,7 +66,7 @@ bool qdScreenTextFormat::load_script(const xml::tag *p) {
 			set_font_type(xml::tag_buffer(*it).get_int());
 			break;
 		case QDSCR_GLOBAL_DEPEND:
-			global_depend_ = (0 != xml::tag_buffer(*it).get_int());
+			_global_depend = (0 != xml::tag_buffer(*it).get_int());
 			load_global_depend = true;
 			break;
 		}
@@ -75,7 +75,7 @@ bool qdScreenTextFormat::load_script(const xml::tag *p) {
 	// Если скрипт старый и инфа о связи с глобальным форматом отсутствует, то
 	// является ли формат связанным с глобальным по содержимому
 	if (!load_global_depend)
-		global_depend_ = (global_text_format() == *this);
+		_global_depend = (global_text_format() == *this);
 
 	return true;
 }
@@ -120,17 +120,17 @@ bool qdScreenTextFormat::save_script(Common::WriteStream &fh, int indent) const 
 	return true;
 }
 
-qdScreenText::qdScreenText(const char *p, const Vect2i &pos, qdGameObjectState *owner) : pos_(pos),
-	size_(0, 0),
-	owner_(owner) {
+qdScreenText::qdScreenText(const char *p, const Vect2i &pos, qdGameObjectState *owner) : _pos(pos),
+	_size(0, 0),
+	_owner(owner) {
 	set_data(p);
 }
 
-qdScreenText::qdScreenText(const char *p, const qdScreenTextFormat &fmt, const Vect2i &pos, qdGameObjectState *owner) : pos_(pos),
-	size_(0, 0),
-	text_format_(fmt),
-	owner_(owner) {
-	hover_mode_ = false;
+qdScreenText::qdScreenText(const char *p, const qdScreenTextFormat &fmt, const Vect2i &pos, qdGameObjectState *owner) : _pos(pos),
+	_size(0, 0),
+	_text_format(fmt),
+	_owner(owner) {
+	_hover_mode = false;
 
 	set_data(p);
 }
@@ -139,30 +139,30 @@ qdScreenText::~qdScreenText() {
 }
 
 void qdScreenText::redraw(const Vect2i &owner_pos) const {
-	int x = owner_pos.x + pos_.x;
-	int y = owner_pos.y + pos_.y;
+	int x = owner_pos.x + _pos.x;
+	int y = owner_pos.y + _pos.y;
 
-	unsigned col = hover_mode_ ? text_format_.hover_color() : text_format_.color();
+	unsigned col = _hover_mode ? _text_format.hover_color() : _text_format.color();
 
 	const grFont *font = qdGameDispatcher::get_dispatcher()->
-	                     find_font(text_format_.font_type());
+	                     find_font(_text_format.font_type());
 
-	grDispatcher::instance()->DrawAlignedText(x, y, size_.x, size_.y, col, data(), grTextAlign(text_format_.alignment()), 0, 0, font);
+	grDispatcher::instance()->DrawAlignedText(x, y, _size.x, _size.y, col, data(), grTextAlign(_text_format.alignment()), 0, 0, font);
 	if (qdGameConfig::get_config().debug_draw())
-		grDispatcher::instance()->Rectangle(x, y, size_.x, size_.y, col, 0, GR_OUTLINED);
+		grDispatcher::instance()->Rectangle(x, y, _size.x, _size.y, col, 0, GR_OUTLINED);
 }
 
 void qdScreenText::set_data(const char *p) {
-	data_ = p;
+	_data = p;
 
 	const grFont *font = qdGameDispatcher::get_dispatcher()->
-	                     find_font(text_format_.font_type());
-	size_.x = grDispatcher::instance()->TextWidth(data(), 0, font);
-	size_.y = grDispatcher::instance()->TextHeight(data(), 0, font);
+	                     find_font(_text_format.font_type());
+	_size.x = grDispatcher::instance()->TextWidth(data(), 0, font);
+	_size.y = grDispatcher::instance()->TextHeight(data(), 0, font);
 }
 
 bool qdScreenText::is_owned_by(const qdNamedObject *p) const {
-	return (owner_ && p == owner_->owner());
+	return (_owner && p == _owner->owner());
 }
 
 bool qdScreenText::format_text(int max_width) {
@@ -173,13 +173,13 @@ bool qdScreenText::format_text(int max_width) {
 	bool correct = true;
 	int safe_space = -1;
 	int cur_wid = 0;
-	data_ += ' '; // Добавляем пробел для упрощения алгоритма (из-за последнего
+	_data += ' '; // Добавляем пробел для упрощения алгоритма (из-за последнего
 	// пробела в конце всегда включится попытка форматирования конца).
 	// Пробел не отразиться на выводе, т.к. он в конце.
 
-	unsigned char *dp = (unsigned char *)data_.c_str();
+	unsigned char *dp = (unsigned char *)_data.c_str();
 
-	for (int i = 0; i < data_.length(); i++) {
+	for (int i = 0; i < _data.length(); i++) {
 		if (dp[i] == '\n') {
 			if (cur_wid > max_width) {
 				// безопасный пробел есть - безопасно режем (т.е. все влезает в max_width)
@@ -227,9 +227,9 @@ bool qdScreenText::format_text(int max_width) {
 		}
 	}
 
-	data_.erase(data_.length() - 1, 1); // Удаляем последний символ (пробел добавленный нами)
+	_data.erase(_data.length() - 1, 1); // Удаляем последний символ (пробел добавленный нами)
 
-	set_data(data_.c_str()); // Устанавливаем данные (для пересчета размера текста)
+	set_data(_data.c_str()); // Устанавливаем данные (для пересчета размера текста)
 
 	return correct;
 }

--- a/qdcore/qd_screen_text.h
+++ b/qdcore/qd_screen_text.h
@@ -59,12 +59,12 @@ public:
 	~qdScreenTextFormat() { };
 
 	bool operator == (const qdScreenTextFormat &fmt) const {
-		return (color_ == fmt.color_ &&
-		        arrangement_ == fmt.arrangement_ &&
-		        alignment_ == fmt.alignment_ &&
-		        hover_color_ == fmt.hover_color_ &&
-		        font_type_ == fmt.font_type() &&
-		        global_depend_ == fmt.is_global_depend());
+		return (_color == fmt._color &&
+		        _arrangement == fmt._arrangement &&
+		        _alignment == fmt._alignment &&
+		        _hover_color == fmt._hover_color &&
+		        _font_type == fmt.font_type() &&
+		        _global_depend == fmt.is_global_depend());
 	}
 
 	bool operator != (const qdScreenTextFormat &fmt) const {
@@ -72,66 +72,66 @@ public:
 	}
 
 	void set_arrangement(arrangement_t al) {
-		arrangement_ = al;
+		_arrangement = al;
 	}
 	arrangement_t arrangement() const {
-		return arrangement_;
+		return _arrangement;
 	}
 
 	void set_alignment(alignment_t al) {
-		alignment_ = al;
+		_alignment = al;
 	}
 	alignment_t alignment() const {
-		return alignment_;
+		return _alignment;
 	}
 
 	void set_color(int color) {
-		color_ = color;
+		_color = color;
 	}
 	int color() const {
-		return color_;
+		return _color;
 	}
 
 	void set_hover_color(int color) {
-		hover_color_ = color;
+		_hover_color = color;
 	}
 	int hover_color() const {
-		return hover_color_;
+		return _hover_color;
 	}
 
 	//! Возвращает формат текста по умолчанию.
 	static const qdScreenTextFormat &default_format() {
-		return default_format_;
+		return _default_format;
 	}
 
 	/// Глобальные настройки формата текста.
 	static const qdScreenTextFormat &global_text_format() {
-		return global_text_format_;
+		return _global_text_format;
 	}
 	static void set_global_text_format(const qdScreenTextFormat &frmt) {
-		global_text_format_ = frmt;
+		_global_text_format = frmt;
 	}
 
 	/// Глобальные настройки формата текста для тем диалогов.
 	static const qdScreenTextFormat &global_topic_format() {
-		return global_topic_format_;
+		return _global_topic_format;
 	}
 	static void set_global_topic_format(const qdScreenTextFormat &frmt) {
-		global_topic_format_ = frmt;
+		_global_topic_format = frmt;
 	}
 
 	void set_font_type(int tp) {
-		font_type_ = tp;
+		_font_type = tp;
 	}
 	int font_type() const {
-		return font_type_;
+		return _font_type;
 	}
 
 	bool is_global_depend() const {
-		return global_depend_;
+		return _global_depend;
 	}
 	void toggle_global_depend(bool flag = true) {
-		global_depend_ = flag;
+		_global_depend = flag;
 	}
 
 	bool load_script(const xml::tag *p);
@@ -140,28 +140,28 @@ public:
 private:
 
 	//! Расположение относительно других текстов.
-	arrangement_t arrangement_;
+	arrangement_t _arrangement;
 	/// Выравнивание текста.
-	alignment_t alignment_;
+	alignment_t _alignment;
 	//! Цвет текста, RGB().
-	int color_;
+	int _color;
 	//! Цвет текста при наведении на него мыши, RGB().
-	int hover_color_;
+	int _hover_color;
 
 	//! Формат текста по умолчанию.
-	static qdScreenTextFormat default_format_;
+	static qdScreenTextFormat _default_format;
 
 	/// Глобальный формат.
-	static qdScreenTextFormat global_text_format_;
+	static qdScreenTextFormat _global_text_format;
 	/// Глобальный формат тем диалогов.
-	static qdScreenTextFormat global_topic_format_;
+	static qdScreenTextFormat _global_topic_format;
 
 	//! Тип шрифта
-	int font_type_;
+	int _font_type;
 
-	/** Флаг, означающий, что данные должны браться из global_text_format_ или
+	/** Флаг, означающий, что данные должны браться из _gloabal_text_format или
 	    global_topic_format_ вместо текущей переменной. */
-	bool global_depend_;
+	bool _global_depend;
 };
 
 //! Экранный текст.
@@ -173,15 +173,15 @@ public:
 
 	//! Экранные координаты центра текста.
 	Vect2i screen_pos() {
-		return pos_;
+		return _pos;
 	}
 	//! Устанавливает экранные координаты центра текста.
 	void set_screen_pos(const Vect2i &pos) {
-		pos_ = pos;
+		_pos = pos;
 	}
 
 	const char *data() const {
-		return data_.c_str();
+		return _data.c_str();
 	}
 	//! Устанавливает текст.
 	/**
@@ -191,62 +191,62 @@ public:
 
 	//! Горизонтальный размер текста в пикселах.
 	int size_x() const {
-		return size_.x;
+		return _size.x;
 	}
 	//! Вертикальный размер текста в пикселах.
 	int size_y() const {
-		return size_.y;
+		return _size.y;
 	}
 
 	qdScreenTextFormat::arrangement_t arrangement() const {
-		return text_format_.arrangement();
+		return _text_format.arrangement();
 	}
 	qdScreenTextFormat::alignment_t alignment() const {
-		return text_format_.alignment();
+		return _text_format.alignment();
 	}
 
 	qdScreenTextFormat text_format() const {
-		return text_format_;
+		return _text_format;
 	}
 	void set_text_format(const qdScreenTextFormat &fmt) {
-		text_format_ = fmt;
+		_text_format = fmt;
 	}
 
 	grScreenRegion screen_region() const {
-		return grScreenRegion(pos_.x, pos_.y, size_.x, size_.y);
+		return grScreenRegion(_pos.x, _pos.y, _size.x, _size.y);
 	}
 
 	//! Отрисовка текста.
 	void redraw(const Vect2i &owner_pos) const;
 
 	unsigned color() const {
-		return text_format_.color();
+		return _text_format.color();
 	}
 	void set_color(unsigned col) {
-		text_format_.set_color(col);
+		_text_format.set_color(col);
 	}
 
 	//! Возвращает указатель на владельца текста.
 	qdGameObjectState *owner() const {
-		return owner_;
+		return _owner;
 	}
 	//! Устанавливает владельца текста.
 	void set_owner(qdGameObjectState *p) {
-		owner_ = p;
+		_owner = p;
 	}
 	bool is_owned_by(const qdNamedObject *p) const;
 
 	//! Проверка попадания точки в текст, параметры в экранных координатах.
 	bool hit(int x, int y) const {
-		if (x >= pos_.x && x < pos_.x + size_.x) {
-			if (y >= pos_.y && y < pos_.y + size_.y)
+		if (x >= _pos.x && x < _pos.x + _size.x) {
+			if (y >= _pos.y && y < _pos.y + _size.y)
 				return true;
 		}
 		return false;
 	}
 
 	void set_hover_mode(bool state) {
-		hover_mode_ = state;
+		_hover_mode = state;
 	}
 
 	// форматирует текст так, чтобы его ширина не превышала max_width (размер в пикселах)
@@ -255,21 +255,21 @@ public:
 private:
 
 	//! Экранные координаты текста.
-	Vect2i pos_;
+	Vect2i _pos;
 	//! Размеры текста в пикселах.
-	Vect2i size_;
+	Vect2i _size;
 
 	//! Текст (данные).
-	std::string data_;
+	std::string _data;
 
 	//! true, если над текстом курсор мыши
-	bool hover_mode_;
+	bool _hover_mode;
 
 	//! Cпособ выравнивания текста.
-	qdScreenTextFormat text_format_;
+	qdScreenTextFormat _text_format;
 
 	//! Владелец текста.
-	mutable qdGameObjectState *owner_;
+	mutable qdGameObjectState *_owner;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_screen_text_dispatcher.cpp
+++ b/qdcore/qd_screen_text_dispatcher.cpp
@@ -28,7 +28,7 @@
 namespace QDEngine {
 
 qdScreenTextDispatcher::qdScreenTextDispatcher() {
-	text_sets_.reserve(16);
+	_text_sets.reserve(16);
 }
 
 qdScreenTextDispatcher::~qdScreenTextDispatcher() {
@@ -38,7 +38,7 @@ qdScreenTextDispatcher::~qdScreenTextDispatcher() {
 void qdScreenTextDispatcher::redraw() const {
 #ifdef _QUEST_EDITOR
 	std::vector<qdScreenTextSet>::const_iterator is;
-	FOR_EACH(text_sets_, is)
+	FOR_EACH(_text_sets, is)
 	is->redraw();
 #endif
 }
@@ -48,30 +48,30 @@ static bool operator == (const qdScreenTextSet &set, int id) {
 }
 
 qdScreenText *qdScreenTextDispatcher::add_text(int set_ID, const qdScreenText &txt) {
-	std::vector<qdScreenTextSet>::iterator it = std::find(text_sets_.begin(), text_sets_.end(), set_ID);
+	std::vector<qdScreenTextSet>::iterator it = std::find(_text_sets.begin(), _text_sets.end(), set_ID);
 
-	if (it != text_sets_.end())
+	if (it != _text_sets.end())
 		return it->add_text(txt);
 
 	return NULL;
 }
 
 void qdScreenTextDispatcher::clear_texts() {
-	for (auto &it : text_sets_) {
+	for (auto &it : _text_sets) {
 		it.clear_texts();
 	}
 }
 
 void qdScreenTextDispatcher::clear_texts(qdNamedObject *p) {
-	for (auto &it : text_sets_) {
+	for (auto &it : _text_sets) {
 		it.clear_texts(p);
 	}
 }
 
 const qdScreenTextSet *qdScreenTextDispatcher::get_text_set(int id) const {
-	std::vector<qdScreenTextSet>::const_iterator it = std::find(text_sets_.begin(), text_sets_.end(), id);
+	std::vector<qdScreenTextSet>::const_iterator it = std::find(_text_sets.begin(), _text_sets.end(), id);
 
-	if (it != text_sets_.end())
+	if (it != _text_sets.end())
 		return &*it;
 
 	return NULL;
@@ -79,9 +79,9 @@ const qdScreenTextSet *qdScreenTextDispatcher::get_text_set(int id) const {
 
 qdScreenTextSet *qdScreenTextDispatcher::get_text_set(int id) {
 	std::vector<qdScreenTextSet>::iterator it =
-	    std::find(text_sets_.begin(), text_sets_.end(), id);
+	    std::find(_text_sets.begin(), _text_sets.end(), id);
 
-	if (it != text_sets_.end())
+	if (it != _text_sets.end())
 		return &*it;
 
 	return NULL;
@@ -89,18 +89,18 @@ qdScreenTextSet *qdScreenTextDispatcher::get_text_set(int id) {
 
 void qdScreenTextDispatcher::pre_redraw() const {
 #ifdef _QUEST_EDITOR
-	std::for_each(text_sets_.begin(), text_sets_.end(), std::mem_fun_ref(qdScreenTextSet::pre_redraw));
+	std::for_each(_text_sets.begin(), _text_sets.end(), std::mem_fun_ref(qdScreenTextSet::pre_redraw));
 #endif
 }
 
 void qdScreenTextDispatcher::post_redraw() {
 #ifdef _QUEST_EDITOR
-	std::for_each(text_sets_.begin(), text_sets_.end(), std::mem_fun_ref(qdScreenTextSet::post_redraw));
+	std::for_each(_text_sets.begin(), _text_sets.end(), std::mem_fun_ref(qdScreenTextSet::post_redraw));
 #endif
 }
 
 bool qdScreenTextDispatcher::save_script(Common::WriteStream &fh, int indent) const {
-	for (auto &it : text_sets_) {
+	for (auto &it : _text_sets) {
 		it.save_script(fh, indent);
 	}
 	return true;

--- a/qdcore/qd_screen_text_dispatcher.h
+++ b/qdcore/qd_screen_text_dispatcher.h
@@ -43,8 +43,8 @@ public:
 	qdScreenText *add_text(int set_ID, const qdScreenText &txt);
 	//! Добавление набора текстов.
 	qdScreenTextSet *add_text_set(const qdScreenTextSet &set) {
-		text_sets_.push_back(set);
-		return &text_sets_.back();
+		_text_sets.push_back(set);
+		return &_text_sets.back();
 	}
 	//! Поиск набора текстов.
 	const qdScreenTextSet *get_text_set(int id) const;
@@ -62,7 +62,7 @@ private:
 
 	typedef std::vector<qdScreenTextSet> text_sets_container_t;
 	//! Наборы текстов.
-	text_sets_container_t text_sets_;
+	text_sets_container_t _text_sets;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_screen_text_set.cpp
+++ b/qdcore/qd_screen_text_set.cpp
@@ -29,14 +29,14 @@
 
 namespace QDEngine {
 
-qdScreenTextSet::qdScreenTextSet() : ID_(0),
-	pos_(0, 0),
-	size_(0, 0),
-	space_(5),
-	was_changed_(false),
-	need_redraw_(false) {
-	max_text_width_ = 0;
-	new_texts_height_ = 0;
+qdScreenTextSet::qdScreenTextSet() : _ID(0),
+	_pos(0, 0),
+	_size(0, 0),
+	_space(5),
+	_was_changed(false),
+	_need_redraw(false) {
+	_max_text_width = 0;
+	_new_texts_height = 0;
 	texts_.reserve(16);
 }
 
@@ -45,7 +45,7 @@ qdScreenTextSet::~qdScreenTextSet() {
 
 void qdScreenTextSet::redraw() const {
 	for (auto &it : texts_) {
-		it.redraw(pos_);
+		it.redraw(_pos);
 	}
 
 //	grDispatcher::instance()->Rectangle(pos_.x - size_.x/2,pos_.y - size_.y/2,size_.x,size_.x,0xFFFFFF,0,GR_OUTLINED);
@@ -56,7 +56,7 @@ bool qdScreenTextSet::arrange_texts() {
 
 	int row_sy = texts_[0].size_y();
 
-	texts_[0].set_screen_pos(Vect2i(space_, 0));
+	texts_[0].set_screen_pos(Vect2i(_space, 0));
 
 	Vect2i text_pos(0, 0);
 
@@ -65,10 +65,10 @@ bool qdScreenTextSet::arrange_texts() {
 			if (row_sy < texts_[i].size_y())
 				row_sy = texts_[i].size_y();
 
-			text_pos.x += texts_[i - 1].size_x() + space_;
+			text_pos.x += texts_[i - 1].size_x() + _space;
 		} else {
 			text_pos.x = 0;
-			text_pos.y += row_sy + space_;
+			text_pos.y += row_sy + _space;
 
 			row_sy = texts_[i].size_y();
 		}
@@ -83,15 +83,15 @@ bool qdScreenTextSet::arrange_texts() {
 		if (texts_[i].arrangement() == qdScreenTextFormat::ARRANGE_VERTICAL || i == texts_.size() - 1) {
 			int sx = 0;
 			for (int j = 0; j < row_size; j++)
-				sx += texts_[row_start + j].size_x() + space_;
+				sx += texts_[row_start + j].size_x() + _space;
 
 			int dx = 0;
 			switch (texts_[row_start].alignment()) {
 			case qdScreenTextFormat::ALIGN_CENTER:
-				dx = (max_text_width_ - sx - space_) / 2;
+				dx = (_max_text_width - sx - _space) / 2;
 				break;
 			case qdScreenTextFormat::ALIGN_RIGHT:
-				dx = max_text_width_ - sx - space_;
+				dx = _max_text_width - sx - _space;
 				break;
 			default:
 				break;
@@ -119,20 +119,20 @@ bool qdScreenTextSet::arrange_texts() {
 			sy = texts_[i].screen_pos().y + texts_[i].size_y();
 	}
 
-	size_ = Vect2i(sx, sy);
+	_size = Vect2i(sx, sy);
 	for (int i = 0; i < texts_.size(); i ++) {
 		Vect2i pos = texts_[i].screen_pos();
-		pos -= size_ / 2;
+		pos -= _size / 2;
 		texts_[i].set_screen_pos(pos);
 	}
 
-	need_redraw_ = true;
+	_need_redraw = true;
 	return true;
 }
 
 qdScreenText *qdScreenTextSet::get_text(int x, int y) {
 	for (auto &it : texts_) {
-		if (it.hit(x - pos_.x, y - pos_.y)) return &it;
+		if (it.hit(x - _pos.x, y - _pos.y)) return &it;
 	}
 
 	return NULL;
@@ -147,17 +147,17 @@ void qdScreenTextSet::clear_texts(qdNamedObject *owner) {
 	}
 
 	if (ret) {
-		need_redraw_ = true;
+		_need_redraw = true;
 		arrange_texts();
 		toggle_changed(true);
 	}
 }
 
 bool qdScreenTextSet::pre_redraw() const {
-	if (need_redraw_) {
+	if (_need_redraw) {
 		if (qdGameDispatcher * dp = qdGameDispatcher::get_dispatcher()) {
 			dp->add_redraw_region(screen_region());
-			dp->add_redraw_region(last_screen_region_);
+			dp->add_redraw_region(_last_screen_region);
 		}
 	}
 
@@ -165,8 +165,8 @@ bool qdScreenTextSet::pre_redraw() const {
 }
 
 bool qdScreenTextSet::post_redraw() {
-	need_redraw_ = false;
-	last_screen_region_ = screen_region();
+	_need_redraw = false;
+	_last_screen_region = screen_region();
 	return true;
 }
 
@@ -182,14 +182,14 @@ void qdScreenTextSet::load_script(const xml::tag *p) {
 	for (xml::tag::subtag_iterator it = p->subtags_begin(); it != p->subtags_end(); ++it) {
 		switch (it->ID()) {
 		case QDSCR_ID:
-			xml::tag_buffer(*it) > ID_;
+			xml::tag_buffer(*it) > _ID;
 			break;
 		case QDSCR_POS2D:
 			xml::tag_buffer(*it) > r.x > r.y;
-			pos_ = r;
+			_pos = r;
 			break;
 		case QDSCR_SCREEN_SIZE:
-			xml::tag_buffer(*it) > size_.x > size_.y;
+			xml::tag_buffer(*it) > _size.x > _size.y;
 			break;
 		}
 	}
@@ -200,14 +200,14 @@ bool qdScreenTextSet::save_script(Common::WriteStream &fh, int indent) const {
 		fh.writeString("\t");
 	}
 
-	fh.writeString(Common::String::format("<text_set ID=\"%d\"", ID_));
+	fh.writeString(Common::String::format("<text_set ID=\"%d\"", _ID));
 
-	if (pos_.x || pos_.y) {
-		fh.writeString(Common::String::format(" pos_2d=\"%d %d\"", pos_.x, pos_.y));
+	if (_pos.x || _pos.y) {
+		fh.writeString(Common::String::format(" pos_2d=\"%d %d\"", _pos.x, _pos.y));
 	}
 
-	if (size_.x || size_.y) {
-		fh.writeString(Common::String::format(" screen_size=\"%d %d\"", size_.x, size_.y));
+	if (_size.x || _size.y) {
+		fh.writeString(Common::String::format(" screen_size=\"%d %d\"", _size.x, _size.y));
 	}
 
 	fh.writeString("/>\r\n");
@@ -216,17 +216,17 @@ bool qdScreenTextSet::save_script(Common::WriteStream &fh, int indent) const {
 }
 
 qdScreenText *qdScreenTextSet::add_text(const qdScreenText &txt) {
-	int sy = size_.y;
+	int sy = _size.y;
 
 	texts_.push_back(txt);
 
-	if (max_text_width_)
-		texts_.back().format_text(max_text_width_ - space_ * 2);
+	if (_max_text_width)
+		texts_.back().format_text(_max_text_width - _space * 2);
 
 	arrange_texts();
 	toggle_changed(true);
 
-	new_texts_height_ += size_.y - sy;
+	_new_texts_height += _size.y - sy;
 
 	return &texts_.back();
 }
@@ -238,9 +238,9 @@ void qdScreenTextSet::clear_hover_mode() {
 
 
 void qdScreenTextSet::format_texts() {
-	if (!max_text_width_) return;
+	if (!_max_text_width) return;
 
 	for (texts_container_t::iterator it = texts_.begin(); it != texts_.end(); ++it)
-		it->format_text(max_text_width_);
+		it->format_text(_max_text_width);
 }
 } // namespace QDEngine

--- a/qdcore/qd_screen_text_set.h
+++ b/qdcore/qd_screen_text_set.h
@@ -65,7 +65,7 @@ public:
 	qdScreenText *add_text(const qdScreenText &txt);
 	//! Очистка всех текстов набора.
 	void clear_texts() {
-		texts_.clear();
+		_texts.clear();
 		arrange_texts();
 	}
 	//! Очистка всех текстов с владельцем owner.
@@ -89,7 +89,7 @@ public:
 	}
 
 	bool is_empty() const {
-		return texts_.empty();
+		return _texts.empty();
 	}
 
 	void set_max_text_width(int width) {
@@ -132,7 +132,7 @@ private:
 
 	typedef std::vector<qdScreenText> texts_container_t;
 	//! Тексты.
-	texts_container_t texts_;
+	texts_container_t _texts;
 
 	//! Устанавливается в true при добавлении/удалении текстов.
 	bool _was_changed;

--- a/qdcore/qd_screen_text_set.h
+++ b/qdcore/qd_screen_text_set.h
@@ -36,29 +36,29 @@ public:
 
 	//! Возвращает идентификатор набора.
 	int ID() const {
-		return ID_;
+		return _ID;
 	}
 	//! Устанавливает идентификатор набора.
 	void set_ID(int id) {
-		ID_ = id;
+		_ID = id;
 	}
 
 	//! Возвращает экранные координаты центра набора.
 	const Vect2i &screen_pos() const {
-		return pos_;
+		return _pos;
 	}
 	//! Устанавливает экранные координаты центра набора.
 	void set_screen_pos(const Vect2i &pos) {
-		pos_ = pos;
+		_pos = pos;
 	}
 
 	//! Возвращает размеры набора на экране.
 	const Vect2i &screen_size() const {
-		return size_;
+		return _size;
 	}
 	//! Устанавливает размеры набора на экране.
 	void set_screen_size(const Vect2i &sz) {
-		size_ = sz;
+		_size = sz;
 	}
 
 	//! Добавление текста в набор.
@@ -85,7 +85,7 @@ public:
 	bool save_script(Common::WriteStream &fh, int indent) const;
 
 	bool need_redraw() const {
-		return need_redraw_;
+		return _need_redraw;
 	}
 
 	bool is_empty() const {
@@ -93,7 +93,7 @@ public:
 	}
 
 	void set_max_text_width(int width) {
-		max_text_width_ = width;
+		_max_text_width = width;
 		format_texts();
 		arrange_texts();
 	}
@@ -102,17 +102,17 @@ public:
 	qdScreenText *get_text(int x, int y);
 
 	bool was_changed() const {
-		return was_changed_;
+		return _was_changed;
 	}
 	void toggle_changed(bool state) {
-		was_changed_ = state;
+		_was_changed = state;
 	}
 
 	int new_texts_height() const {
-		return new_texts_height_;
+		return _new_texts_height;
 	}
 	void clear_new_texts_height() {
-		new_texts_height_ = 0;
+		_new_texts_height = 0;
 	}
 
 	void clear_hover_mode();
@@ -120,33 +120,33 @@ public:
 private:
 
 	//! Идентификатор набора.
-	int ID_;
+	int _ID;
 
 	//! Экранные координаты центра набора.
-	Vect2i pos_;
+	Vect2i _pos;
 	//! Размеры области, отведенной под набор на экране.
-	Vect2i size_;
+	Vect2i _size;
 
 	//! Расстояние между соседними текстами в пикселах.
-	int space_;
+	int _space;
 
 	typedef std::vector<qdScreenText> texts_container_t;
 	//! Тексты.
 	texts_container_t texts_;
 
 	//! Устанавливается в true при добавлении/удалении текстов.
-	bool was_changed_;
+	bool _was_changed;
 
 	//! Максимальная ширина текста в пикселах.
 	/**
 	Если нулевая - не учитывается.
 	*/
-	int max_text_width_;
+	int _max_text_width;
 
-	int new_texts_height_;
+	int _new_texts_height;
 
-	bool need_redraw_;
-	grScreenRegion last_screen_region_;
+	bool _need_redraw;
+	grScreenRegion _last_screen_region;
 
 	//! Форматирует тексты по ширине, чтобы не вылезали за max_text_width_.
 	void format_texts();

--- a/qdcore/qd_setup.cpp
+++ b/qdcore/qd_setup.cpp
@@ -35,8 +35,8 @@
 
 namespace QDEngine {
 
-const char *const qdGameConfig::ini_name_ = "qd_game.ini";
-qdGameConfig qdGameConfig::config_;
+const char *const qdGameConfig::_ini_name = "qd_game.ini";
+qdGameConfig qdGameConfig::_config;
 
 bool enumerateIniSections(const char *fname, Common::INIFile::SectionList &sectionList) {
 
@@ -84,57 +84,57 @@ void putIniKey(const char *fname, const char *section, const char *key, const ch
 }
 
 qdGameConfig::qdGameConfig() {
-	screen_sx_ = 640;
-	screen_sy_ = 480;
+	_screen_sx = 640;
+	_screen_sy = 480;
 
-	bits_per_pixel_ = 2;
-	debug_draw_ = false;
-	debug_show_grid_ = false;
-	fullscreen_ = true;
-	triggers_debug_ = false;
+	_bits_per_pixel = 2;
+	_debug_draw = false;
+	_debug_show_grid = false;
+	_fullscreen = true;
+	_triggers_debug = false;
 
-	driver_id_ = 1;
-	show_fps_ = false;
-	force_full_redraw_ = false;
+	_driver_id = 1;
+	_show_fps = false;
+	_force_full_redraw = false;
 
-	enable_sound_ = true;
-	sound_volume_ = 255;
-	enable_music_ = true;
-	music_volume_ = 255;
+	_enable_sound = true;
+	_sound_volume = 255;
+	_enable_music = true;
+	_music_volume = 255;
 
-	logic_period_ = 25;
-	logic_synchro_by_clock_ = 1;
-	game_speed_ = 1.0f;
+	_logic_period = 25;
+	_logic_synchro_by_clock = 1;
+	_game_speed = 1.0f;
 
-	is_splash_enabled_ = true;
-	splash_time_ = 3000;
+	_is_splash_enabled = true;
+	_splash_time = 3000;
 
-	enable_profiler_ = false;
+	_enable_profiler = false;
 
-	locale_ = "Russian";
+	_locale = "Russian";
 
-	minigame_read_only_ini_ = false;
+	_minigame_read_only_ini = false;
 }
 
 void qdGameConfig::set_pixel_format(int pf) {
 	switch (pf) {
 	case GR_ARGB1555:
-		bits_per_pixel_ = 0;
+		_bits_per_pixel = 0;
 		break;
 	case GR_RGB565:
-		bits_per_pixel_ = 1;
+		_bits_per_pixel = 1;
 		break;
 	case GR_RGB888:
-		bits_per_pixel_ = 2;
+		_bits_per_pixel = 2;
 		break;
 	case GR_ARGB8888:
-		bits_per_pixel_ = 3;
+		_bits_per_pixel = 3;
 		break;
 	}
 }
 
 int qdGameConfig::bits_per_pixel() const {
-	switch (bits_per_pixel_) {
+	switch (_bits_per_pixel) {
 	case 0:
 		return 15;
 	case 1:
@@ -151,16 +151,16 @@ int qdGameConfig::bits_per_pixel() const {
 void qdGameConfig::set_bits_per_pixel(int bpp) {
 	switch (bpp) {
 	case 15:
-		bits_per_pixel_ = 0;
+		_bits_per_pixel = 0;
 		break;
 	case 16:
-		bits_per_pixel_ = 1;
+		_bits_per_pixel = 1;
 		break;
 	case 24:
-		bits_per_pixel_ = 2;
+		_bits_per_pixel = 2;
 		break;
 	case 32:
-		bits_per_pixel_ = 3;
+		_bits_per_pixel = 3;
 		break;
 	}
 }
@@ -183,79 +183,79 @@ int qdGameConfig::pixel_format() const {
 void qdGameConfig::load() {
 	char *p = 0;
 #ifndef _QUEST_EDITOR
-	p = getIniKey(ini_name_, "graphics", "color_depth");
-	if (strlen(p)) bits_per_pixel_ = atoi(p);
+	p = getIniKey(_ini_name, "graphics", "color_depth");
+	if (strlen(p)) _bits_per_pixel = atoi(p);
 
-	p = getIniKey(ini_name_, "graphics", "fullscreen");
-	if (strlen(p)) fullscreen_ = (atoi(p)) > 0;
+	p = getIniKey(_ini_name, "graphics", "fullscreen");
+	if (strlen(p)) _fullscreen = (atoi(p)) > 0;
 
-	p = getIniKey(ini_name_, "graphics", "driver");
-	if (strlen(p)) driver_id_ = atoi(p);
+	p = getIniKey(_ini_name, "graphics", "driver");
+	if (strlen(p)) _driver_id = atoi(p);
 
-	p = getIniKey(ini_name_, "game", "logic_period");
-	if (strlen(p)) logic_period_ = atoi(p);
+	p = getIniKey(_ini_name, "game", "logic_period");
+	if (strlen(p)) _logic_period = atoi(p);
 
-	p = getIniKey(ini_name_, "game", "synchro_by_clock");
-	if (strlen(p)) logic_synchro_by_clock_ = atoi(p);
+	p = getIniKey(_ini_name, "game", "synchro_by_clock");
+	if (strlen(p)) _logic_synchro_by_clock = atoi(p);
 
-	p = getIniKey(ini_name_, "game", "game_speed");
-	if (strlen(p)) game_speed_ = atof(p);
+	p = getIniKey(_ini_name, "game", "game_speed");
+	if (strlen(p)) _game_speed = atof(p);
 
-	p = getIniKey(ini_name_, "game", "locale");
-	if (strlen(p)) locale_ = p;
+	p = getIniKey(_ini_name, "game", "locale");
+	if (strlen(p)) _locale = p;
 
 #ifndef __QD_SYSLIB__
-	p = getIniKey(ini_name_, "game", "fps_period");
+	p = getIniKey(_ini_name, "game", "fps_period");
 	if (strlen(p)) qdGameScene::fps_counter().set_period(atoi(p));
 #endif
 
-	if (atoi(getIniKey(ini_name_, "debug", "full_redraw")))
-		force_full_redraw_ = true;
+	if (atoi(getIniKey(_ini_name, "debug", "full_redraw")))
+		_force_full_redraw = true;
 
-	if (atoi(getIniKey(ini_name_, "debug", "enable_profiler")))
-		enable_profiler_ = true;
+	if (atoi(getIniKey(_ini_name, "debug", "enable_profiler")))
+		_enable_profiler = true;
 
-	p = getIniKey(ini_name_, "debug", "triggers_log_file");
-	if (strlen(p)) profiler_file_ = p;
+	p = getIniKey(_ini_name, "debug", "triggers_log_file");
+	if (strlen(p)) _profiler_file = p;
 
-	if (atoi(getIniKey(ini_name_, "debug", "triggers_debug")))
-		triggers_debug_ = true;
+	if (atoi(getIniKey(_ini_name, "debug", "triggers_debug")))
+		_triggers_debug = true;
 
-	p = getIniKey(ini_name_, "sound", "enable_sound");
-	if (strlen(p)) enable_sound_ = (atoi(p) > 0);
+	p = getIniKey(_ini_name, "sound", "enable_sound");
+	if (strlen(p)) _enable_sound = (atoi(p) > 0);
 
-	p = getIniKey(ini_name_, "sound", "sound_volume");
-	if (strlen(p)) sound_volume_ = atoi(p);
+	p = getIniKey(_ini_name, "sound", "sound_volume");
+	if (strlen(p)) _sound_volume = atoi(p);
 
-	p = getIniKey(ini_name_, "sound", "enable_music");
-	if (strlen(p)) enable_music_ = (atoi(p) > 0);
+	p = getIniKey(_ini_name, "sound", "enable_music");
+	if (strlen(p)) _enable_music = (atoi(p) > 0);
 
-	p = getIniKey(ini_name_, "sound", "music_volume");
-	if (strlen(p)) music_volume_ = atoi(p);
+	p = getIniKey(_ini_name, "sound", "music_volume");
+	if (strlen(p)) _music_volume = atoi(p);
 #endif
 
-	p = getIniKey(ini_name_, "minigame", "read_only_ini");
-	if (strlen(p)) minigame_read_only_ini_ = (atoi(p) > 0);
+	p = getIniKey(_ini_name, "minigame", "read_only_ini");
+	if (strlen(p)) _minigame_read_only_ini = (atoi(p) > 0);
 }
 
 void qdGameConfig::save() {
 #ifndef _QUEST_EDITOR
-	putIniKey(ini_name_, "graphics", "color_depth", bits_per_pixel_);
-	putIniKey(ini_name_, "graphics", "fullscreen", fullscreen_);
-	putIniKey(ini_name_, "graphics", "driver", driver_id_);
+	putIniKey(_ini_name, "graphics", "color_depth", _bits_per_pixel);
+	putIniKey(_ini_name, "graphics", "fullscreen", _fullscreen);
+	putIniKey(_ini_name, "graphics", "driver", _driver_id);
 
-	putIniKey(ini_name_, "sound", "enable_sound", enable_sound_);
-	putIniKey(ini_name_, "sound", "sound_volume", sound_volume_);
-	putIniKey(ini_name_, "sound", "enable_music", enable_music_);
-	putIniKey(ini_name_, "sound", "music_volume", music_volume_);
+	putIniKey(_ini_name, "sound", "enable_sound", _enable_sound);
+	putIniKey(_ini_name, "sound", "sound_volume", _sound_volume);
+	putIniKey(_ini_name, "sound", "enable_music", _enable_music);
+	putIniKey(_ini_name, "sound", "music_volume", _music_volume);
 #endif
 }
 
 bool qdGameConfig::update_sound_settings() const {
 #ifndef __QD_SYSLIB__
 	if (sndDispatcher * dp = sndDispatcher::get_dispatcher()) {
-		dp->set_volume(sound_volume_);
-		if (enable_sound_) dp->enable();
+		dp->set_volume(_sound_volume);
+		if (_enable_sound) dp->enable();
 		else dp->disable();
 
 		return true;
@@ -266,8 +266,8 @@ bool qdGameConfig::update_sound_settings() const {
 
 bool qdGameConfig::update_music_settings() const {
 #ifndef __QD_SYSLIB__
-	mpegPlayer::instance().set_volume(music_volume_);
-	if (enable_music_) mpegPlayer::instance().enable();
+	mpegPlayer::instance().set_volume(_music_volume);
+	if (_enable_music) mpegPlayer::instance().enable();
 	else mpegPlayer::instance().disable();
 #endif
 	return true;

--- a/qdcore/qd_setup.h
+++ b/qdcore/qd_setup.h
@@ -33,22 +33,22 @@ public:
 	~qdGameConfig() { }
 
 	int screen_sx() const {
-		return screen_sx_;
+		return _screen_sx;
 	}
 	int screen_sy() const {
-		return screen_sy_;
+		return _screen_sy;
 	}
 
 	int driver_ID() const {
-		return driver_id_;
+		return _driver_id;
 	}
 	void set_driver_ID(int id) {
-		driver_id_ = id;
+		_driver_id = id;
 	}
 
 	void set_screen_size(int sx, int sy) {
-		screen_sx_ = sx;
-		screen_sy_ = sy;
+		_screen_sx = sx;
+		_screen_sy = sy;
 	}
 
 	int pixel_format() const;
@@ -58,169 +58,169 @@ public:
 	void set_bits_per_pixel(int bpp);
 
 	bool debug_draw() const {
-		return debug_draw_;
+		return _debug_draw;
 	}
 	void toggle_debug_draw() {
-		debug_draw_ = !debug_draw_;
+		_debug_draw = !_debug_draw;
 	}
 	bool debug_show_grid() const {
-		return debug_show_grid_;
+		return _debug_show_grid;
 	}
 	void toggle_show_grid() {
-		debug_show_grid_ = !debug_show_grid_;
+		_debug_show_grid = !_debug_show_grid;
 	}
 
 	bool force_full_redraw() const {
-		return force_full_redraw_;
+		return _force_full_redraw;
 	}
 	void toggle_full_redraw() {
-		force_full_redraw_ = !force_full_redraw_;
+		_force_full_redraw = !_force_full_redraw;
 	}
 
 	bool fullscreen() const {
-		return fullscreen_;
+		return _fullscreen;
 	}
 	void toggle_fullscreen() {
-		fullscreen_ = !fullscreen_;
+		_fullscreen = !_fullscreen;
 	}
 
 	const char *locale() const {
-		return locale_.c_str();
+		return _locale.c_str();
 	}
 
 	void load();
 	void save();
 
 	static qdGameConfig &get_config() {
-		return config_;
+		return _config;
 	}
 	static void set_config(const qdGameConfig &s) {
-		config_ = s;
+		_config = s;
 	}
 
 	static const char *ini_name() {
-		return ini_name_;
+		return _ini_name;
 	}
 
 	bool triggers_debug() const {
-		return triggers_debug_;
+		return _triggers_debug;
 	}
 	void toggle_triggers_debug(bool v) {
-		triggers_debug_ = v;
+		_triggers_debug = v;
 	}
 
 	bool show_fps() const {
-		return show_fps_;
+		return _show_fps;
 	}
 	void toggle_fps() {
-		show_fps_ = !show_fps_;
+		_show_fps = !_show_fps;
 	}
 
 	bool is_sound_enabled() const {
-		return enable_sound_;
+		return _enable_sound;
 	}
 	void toggle_sound(bool state) {
-		enable_sound_ = state;
+		_enable_sound = state;
 	}
 	unsigned int sound_volume() const {
-		return sound_volume_;
+		return _sound_volume;
 	}
 	void set_sound_volume(unsigned int vol) {
-		sound_volume_ = vol;
+		_sound_volume = vol;
 	}
 	bool update_sound_settings() const;
 
 	bool is_music_enabled() const {
-		return enable_music_;
+		return _enable_music;
 	}
 	void toggle_music(bool state) {
-		enable_music_ = state;
+		_enable_music = state;
 	}
 	unsigned int music_volume() const {
-		return music_volume_;
+		return _music_volume;
 	}
 	void set_music_volume(unsigned int vol) {
-		music_volume_ = vol;
+		_music_volume = vol;
 	}
 	bool update_music_settings() const;
 
 	int logic_period() const {
-		return logic_period_;
+		return _logic_period;
 	}
 	int logic_synchro_by_clock() const {
-		return logic_synchro_by_clock_;
+		return _logic_synchro_by_clock;
 	}
 
 	float game_speed() const {
-		return game_speed_;
+		return _game_speed;
 	}
 	void set_game_speed(float speed) {
-		game_speed_ = speed;
+		_game_speed = speed;
 	}
 
 	bool is_splash_enabled() const {
-		return is_splash_enabled_;
+		return _is_splash_enabled;
 	}
 	int splash_time() const {
-		return splash_time_;
+		return _splash_time;
 	}
 
 	bool is_profiler_enabled() const {
-		return enable_profiler_;
+		return _enable_profiler;
 	}
 	void toggle_profiler(bool state) {
-		enable_profiler_ = state;
+		_enable_profiler = state;
 	}
 	const char *profiler_file() const {
-		return profiler_file_.c_str();
+		return _profiler_file.c_str();
 	}
 	void set_profiler_file(const char *fname) {
-		profiler_file_ = fname;
+		_profiler_file = fname;
 	}
 
 	bool minigame_read_only_ini() const {
-		return minigame_read_only_ini_;
+		return _minigame_read_only_ini;
 	}
 
 private:
 
-	int bits_per_pixel_;
-	bool fullscreen_;
+	int _bits_per_pixel;
+	bool _fullscreen;
 
-	int driver_id_;
+	int _driver_id;
 
-	int screen_sx_;
-	int screen_sy_;
+	int _screen_sx;
+	int _screen_sy;
 
-	bool enable_sound_;
-	unsigned int sound_volume_;
+	bool _enable_sound;
+	unsigned int _sound_volume;
 
-	bool enable_music_;
-	unsigned int music_volume_;
+	bool _enable_music;
+	unsigned int _music_volume;
 
-	bool debug_draw_;
-	bool debug_show_grid_;
+	bool _debug_draw;
+	bool _debug_show_grid;
 
-	bool triggers_debug_;
-	bool show_fps_;
-	bool force_full_redraw_;
+	bool _triggers_debug;
+	bool _show_fps;
+	bool _force_full_redraw;
 
-	int logic_period_;
-	int logic_synchro_by_clock_;
-	float game_speed_;
+	int _logic_period;
+	int _logic_synchro_by_clock;
+	float _game_speed;
 
-	bool is_splash_enabled_;
-	int splash_time_;
+	bool _is_splash_enabled;
+	int _splash_time;
 
-	bool enable_profiler_;
-	std::string profiler_file_;
+	bool _enable_profiler;
+	std::string _profiler_file;
 
-	std::string locale_;
+	std::string _locale;
 
-	bool minigame_read_only_ini_;
+	bool _minigame_read_only_ini;
 
-	static qdGameConfig config_;
-	static const char *const ini_name_;
+	static qdGameConfig _config;
+	static const char *const _ini_name;
 };
 
 char *getIniKey(const char *fname, const char *section, const char *key);

--- a/qdcore/qd_sound_handle.h
+++ b/qdcore/qd_sound_handle.h
@@ -30,18 +30,18 @@ namespace QDEngine {
 //! Класс для управления звуками.
 class qdSoundHandle : public sndHandle {
 public:
-	qdSoundHandle() : owner_(NULL) { };
+	qdSoundHandle() : _owner(NULL) { };
 	virtual ~qdSoundHandle() { };
 
 	void set_owner(qdNamedObject *p) {
-		owner_ = p;
+		_owner = p;
 	}
 	const qdNamedObject *owner() const {
-		return owner_;
+		return _owner;
 	}
 
 private:
-	qdNamedObject *owner_;
+	qdNamedObject *_owner;
 };
 
 } // namespace QDEngine

--- a/qdcore/qd_sprite.h
+++ b/qdcore/qd_sprite.h
@@ -48,56 +48,56 @@ public:
 	qdSprite &operator = (const qdSprite &spr);
 
 	const Vect2i &size() const {
-		return size_;
+		return _size;
 	}
 	void set_size(const Vect2i &size) {
-		size_ = size;
+		_size = size;
 	}
 
 	int size_x() const {
-		return size_.x;
+		return _size.x;
 	}
 	int size_y() const {
-		return size_.y;
+		return _size.y;
 	}
 
 	int picture_x() const {
-		return picture_offset_.x;
+		return _picture_offset.x;
 	}
 	int picture_y() const {
-		return picture_offset_.y;
+		return _picture_offset.y;
 	}
 	void set_picture_offset(const Vect2i &offs) {
-		picture_offset_ = offs;
+		_picture_offset = offs;
 	}
 
-	int picture_size_x() const {
-		return picture_size_.x;
+	int picture__sizex() const {
+		return _picture_size.x;
 	}
-	int picture_size_y() const {
-		return picture_size_.y;
+	int _picture_sizey() const {
+		return _picture_size.y;
 	}
 	void set_picture_size(const Vect2i &size) {
-		picture_size_ = size;
+		_picture_size = size;
 	}
 
 	int format() const {
-		return format_;
+		return _format;
 	}
 	const unsigned char *data() const {
-		return data_;
+		return _data;
 	}
 	unsigned data_size() const;
 
 	void set_file(const char *fname) {
-		if (fname) file_ = fname;
-		else file_.clear();
+		if (fname) _file = fname;
+		else _file.clear();
 	}
 	const char *file() const {
-		return file_.c_str();
+		return _file.c_str();
 	}
 	bool has_file() const {
-		return !file_.empty();
+		return !_file.empty();
 	}
 
 	bool load(const char *fname = 0);
@@ -135,29 +135,29 @@ public:
 	bool compress();
 	bool uncompress();
 	bool is_compressed() const {
-		if (rle_data_) return true;
+		if (_rle_data) return true;
 		else return false;
 	}
 
 	bool scale(float coeff_x, float coeff_y);
 
 	void set_flag(int fl) {
-		flags_ |= fl;
+		_flags |= fl;
 	}
 	void drop_flag(int fl) {
-		flags_ &= ~fl;
+		_flags &= ~fl;
 	}
 	bool check_flag(int fl) const {
-		if (flags_ & fl) {
+		if (_flags & fl) {
 			return true;
 		}
 		return false;
 	}
 	void clear_flags() {
-		flags_ = 0;
+		_flags = 0;
 	}
 	int flags() const {
-		return flags_;
+		return _flags;
 	}
 
 	//! Загружает в память данные ресурса.
@@ -171,8 +171,8 @@ public:
 	}
 
 	//! Устанавливает имя файла, в котором хранятся данные ресурса.
-	void set_resource_file(const char *file_name) {
-		set_file(file_name);
+	void set_resource_file(const char *_filename) {
+		set_file(_filename);
 	}
 	//! Возвращает имя файла, в котором хранятся данные ресурса.
 	/**
@@ -183,7 +183,7 @@ public:
 		return NULL;
 	}
 #ifdef __QD_DEBUG_ENABLE__
-	unsigned resource_data_size() const {
+	unsigned resource__datasize() const {
 		return data_size();
 	}
 #endif
@@ -197,18 +197,18 @@ public:
 	grScreenRegion screen_region(int mode = 0, float scale = 1.0f) const;
 
 private:
-	int format_;
-	int flags_;
+	int _format;
+	int _flags;
 
-	Vect2i size_;
+	Vect2i _size;
 
-	Vect2i picture_size_;
-	Vect2i picture_offset_;
+	Vect2i _picture_size;
+	Vect2i _picture_offset;
 
-	unsigned char *data_;
-	class rleBuffer *rle_data_;
+	unsigned char *_data;
+	class rleBuffer *_rle_data;
 
-	std::string file_;
+	std::string _file;
 
 	friend bool operator == (const qdSprite &sp1, const qdSprite &sp2);
 };

--- a/qdcore/qd_sprite.h
+++ b/qdcore/qd_sprite.h
@@ -71,10 +71,10 @@ public:
 		_picture_offset = offs;
 	}
 
-	int picture__sizex() const {
+	int picture_size_x() const {
 		return _picture_size.x;
 	}
-	int _picture_sizey() const {
+	int picture_size_y() const {
 		return _picture_size.y;
 	}
 	void set_picture_size(const Vect2i &size) {
@@ -183,7 +183,7 @@ public:
 		return NULL;
 	}
 #ifdef __QD_DEBUG_ENABLE__
-	unsigned resource__datasize() const {
+	unsigned resource_data_size() const {
 		return data_size();
 	}
 #endif

--- a/qdcore/qd_textdb.cpp
+++ b/qdcore/qd_textdb.cpp
@@ -42,18 +42,18 @@ qdTextDB &qdTextDB::instance() {
 }
 
 const char *qdTextDB::getText(const char *text_id) const {
-	qdTextMap::const_iterator it = texts_.find(text_id);
-	if (it != texts_.end())
-		return it->second.text_.c_str();
+	qdTextMap::const_iterator it = _texts.find(text_id);
+	if (it != _texts.end())
+		return it->second._text.c_str();
 
 	static const char *const str = "";
 	return str;
 }
 
 const char *qdTextDB::getSound(const char *text_id) const {
-	qdTextMap::const_iterator it = texts_.find(text_id);
-	if (it != texts_.end())
-		return it->second.sound_.c_str();
+	qdTextMap::const_iterator it = _texts.find(text_id);
+	if (it != _texts.end())
+		return it->second._sound.c_str();
 
 	static const char *const str = "";
 	return str;
@@ -61,9 +61,9 @@ const char *qdTextDB::getSound(const char *text_id) const {
 
 const char *qdTextDB::getComment(const char *text_id) const {
 #ifndef _FINAL_VERSION_
-	qdTextMap::const_iterator it = texts_.find(text_id);
-	if (it != texts_.end())
-		return it->second.comment_.c_str();
+	qdTextMap::const_iterator it = _texts.find(text_id);
+	if (it != _texts.end())
+		return it->second._comment.c_str();
 #endif
 
 	static const char *const str = "";
@@ -87,7 +87,7 @@ bool qdTextDB::load(Common::SeekableReadStream *fh, const char *commentsFileName
 		int32 sndLength = fh->readSint32LE();
 		Common::String sndStr = fh->readString(0, sndLength);
 
-		texts_.insert(qdTextMap::value_type(idStr.c_str(), qdText(txtStr.c_str(), sndStr.c_str())));
+		_texts.insert(qdTextMap::value_type(idStr.c_str(), qdText(txtStr.c_str(), sndStr.c_str())));
 
 	}
 
@@ -109,9 +109,9 @@ bool qdTextDB::load(Common::SeekableReadStream *fh, const char *commentsFileName
 			int32 sndLength = fh->readSint32LE();
 			Common::String sndStr = fh->readString(0, sndLength);
 
-			qdTextMap::iterator it = texts_.find(idStr.c_str());
-			if (it != texts_.end())
-				it->second.comment_ = txtStr.c_str();
+			qdTextMap::iterator it = _texts.find(idStr.c_str());
+			if (it != _texts.end())
+				it->second._comment = txtStr.c_str();
 		}
 	}
 
@@ -122,7 +122,7 @@ void qdTextDB::getIdList(const char *mask, IdList &idList) const {
 	idList.clear();
 //	int const maskLen = _tcslen(mask);
 	int const maskLen = strlen(mask);
-	for (auto &i : texts_) {
+	for (auto &i : _texts) {
 		if (!i.first.find(mask)) {
 			std::string str = i.first;
 			str.erase(0, maskLen + 1);
@@ -156,7 +156,7 @@ bool qdTextDB::getIdList(IdList &idList) const {
 }
 
 bool qdTextDB::getRootIdList(IdList &idList) const {
-	qdTextMap::const_iterator i = texts_.begin(), e = texts_.end();
+	qdTextMap::const_iterator i = _texts.begin(), e = _texts.end();
 	std::string copy;
 	for (; i != e; ++i) {
 		std::string const &str = i->first;
@@ -172,4 +172,3 @@ bool qdTextDB::getRootIdList(IdList &idList) const {
 	return true;
 }
 } // namespace QDEngine
-

--- a/qdcore/qd_textdb.h
+++ b/qdcore/qd_textdb.h
@@ -36,7 +36,7 @@ public:
 
 	/// Очистка базы.
 	void clear() {
-		texts_.clear();
+		_texts.clear();
 	}
 
 	/// Возвращает текст с идентификатором text_id.
@@ -68,20 +68,19 @@ public:
 private:
 
 	struct qdText {
-		qdText(const char *text, const char *snd) : text_(text), sound_(snd) { }
+		qdText(const char *text, const char *snd) : _text(text), _sound(snd) { }
 
-		std::string text_;
-		std::string sound_;
+		std::string _text;
+		std::string _sound;
 #ifndef _FINAL_VERSION_
-		std::string comment_;
+		std::string _comment;
 #endif
 	};
 
 	typedef std::unordered_map<std::string, qdText> qdTextMap;
-	qdTextMap texts_;
+	qdTextMap _texts;
 };
 
 } // namespace QDEngine
 
 #endif // QDENGINE_QDCORE_QD_TEXTDB_H
-

--- a/qdcore/qd_trigger_profiler.cpp
+++ b/qdcore/qd_trigger_profiler.cpp
@@ -33,9 +33,9 @@
 
 namespace QDEngine {
 
-const char *const qdTriggerProfiler::activation_comline_ = "trigger_profiler";
+const char *const qdTriggerProfiler::_activation_comline = "trigger_profiler";
 
-int qdTriggerProfiler::record_text_format_ = PROFILER_TEXT_TIME | PROFILER_TEXT_TRIGGER_NAME | PROFILER_TEXT_SCENE_NAME;
+int qdTriggerProfiler::_record_text_format = PROFILER_TEXT_TIME | PROFILER_TEXT_TRIGGER_NAME | PROFILER_TEXT_SCENE_NAME;
 
 qdTriggerProfilerRecord::qdTriggerProfilerRecord() : time_(0),
 	event_(ELEMENT_STATUS_UPDATE),
@@ -109,12 +109,12 @@ bool qdTriggerProfilerRecord::load(Common::SeekableReadStream &fh) {
 	return true;
 }
 
-qdTriggerProfiler::qdTriggerProfiler() : is_logging_enabled_(false), is_read_only_(true) {
-	work_file_ = "trigger_profiler.dat";
+qdTriggerProfiler::qdTriggerProfiler() : _is_logging_enabled(false), _is_read_only(true) {
+	_work_file = "trigger_profiler.dat";
 }
 
 qdTriggerProfiler::~qdTriggerProfiler() {
-	if (is_logging_enabled_)
+	if (_is_logging_enabled)
 		save_to_work_file();
 }
 
@@ -122,8 +122,8 @@ bool qdTriggerProfiler::save_to_work_file() const {
 	warning("STUB: qdTriggerProfiler::save_to_work_file()");
 	Common::DumpFile fh;
 
-	fh.writeUint32LE(records_.size());
-	for (auto &it : records_) {
+	fh.writeUint32LE(_records.size());
+	for (auto &it : _records) {
 		it.save(fh);
 	}
 
@@ -135,13 +135,13 @@ bool qdTriggerProfiler::load_from_work_file() {
 	warning("STUB: qdTriggerProfiler::load_from_work_file()");
 	Common::File fh;
 
-	records_.clear();
+	_records.clear();
 
-	if (fh.open(work_file_.c_str())) {
+	if (fh.open(_work_file.c_str())) {
 		int size;
 		size = fh.readSint32LE();
-		records_.resize(size);
-		for (record_container_t::iterator it = records_.begin(); it != records_.end(); ++it)
+		_records.resize(size);
+		for (record_container_t::iterator it = _records.begin(); it != _records.end(); ++it)
 			it->load(fh);
 
 		fh.close();
@@ -183,21 +183,21 @@ qdTriggerChain *qdTriggerProfiler::get_record_trigger(const qdTriggerProfilerRec
 }
 
 bool qdTriggerProfiler::evolve(int record_num) const {
-	assert(record_num >= 0 && record_num < records_.size());
+	assert(record_num >= 0 && record_num < _records.size());
 
 	if (qdGameDispatcher * p = qdGameDispatcher::get_dispatcher())
 		p->reset_triggers();
 
 	for (int i = 0; i <= record_num; i++) {
-		switch (records_[i].event()) {
+		switch (_records[i].event()) {
 		case qdTriggerProfilerRecord::ELEMENT_STATUS_UPDATE:
-			if (qdTriggerElementPtr p = get_record_element(records_[i]))
-				p->set_status(qdTriggerElement::ElementStatus(records_[i].status()));
+			if (qdTriggerElementPtr p = get_record_element(_records[i]))
+				p->set_status(qdTriggerElement::ElementStatus(_records[i].status()));
 			break;
 		case qdTriggerProfilerRecord::PARENT_LINK_STATUS_UPDATE:
 		case qdTriggerProfilerRecord::CHILD_LINK_STATUS_UPDATE:
-			if (qdTriggerLink * p = get_record_link(records_[i]))
-				p->set_status(qdTriggerLink::LinkStatus(records_[i].status()));
+			if (qdTriggerLink * p = get_record_link(_records[i]))
+				p->set_status(qdTriggerLink::LinkStatus(_records[i].status()));
 			break;
 		}
 	}
@@ -212,8 +212,8 @@ qdTriggerProfiler &qdTriggerProfiler::instance() {
 }
 
 void qdTriggerProfiler::set_work_file(const char *fname) {
-	if (NULL != fname) work_file_ = fname;
-	else work_file_.clear();
+	if (NULL != fname) _work_file = fname;
+	else _work_file.clear();
 }
 
 #endif /* __QD_TRIGGER_PROFILER__ */

--- a/qdcore/qd_trigger_profiler.h
+++ b/qdcore/qd_trigger_profiler.h
@@ -121,41 +121,41 @@ public:
 	bool load_from_work_file();
 
 	void add_record(const qdTriggerProfilerRecord &rec) {
-		if (is_logging_enabled_ && !is_read_only_) records_.push_back(rec);
+		if (_is_logging_enabled && !_is_read_only) _records.push_back(rec);
 	}
 
 	int num_records() const {
-		return records_.size();
+		return _records.size();
 	}
 
 	bool is_logging_enabled() const {
-		return is_logging_enabled_;
+		return _is_logging_enabled;
 	}
 	void enable() {
-		is_logging_enabled_ = true;
+		_is_logging_enabled = true;
 	}
 	void disable() {
-		is_logging_enabled_ = false;
+		_is_logging_enabled = false;
 	}
 
 	void set_read_only(bool v) {
-		is_read_only_ = v;
+		_is_read_only = v;
 	}
 	bool is_read_only() const {
-		return is_read_only_;
+		return _is_read_only;
 	}
 
 	typedef std::vector<qdTriggerProfilerRecord> record_container_t;
 	typedef record_container_t::const_iterator record_iterator_t;
 
 	record_iterator_t records_begin() const {
-		return records_.begin();
+		return _records.begin();
 	}
 	record_iterator_t records_end() const {
-		return records_.end();
+		return _records.end();
 	}
 	record_iterator_t get_record(int record_num = 0) const {
-		return records_.begin() + record_num;
+		return _records.begin() + record_num;
 	}
 
 	bool evolve(int record_num) const;
@@ -163,18 +163,18 @@ public:
 	static qdTriggerProfiler &instance();
 
 	static const char *activation_comline() {
-		return activation_comline_;
+		return _activation_comline;
 	}
 
 	static int record_text_format() {
-		return record_text_format_;
+		return _record_text_format;
 	}
 	static void set_record_text_format(int fmt) {
-		record_text_format_ = fmt;
+		_record_text_format = fmt;
 	}
 
 	const char *work_file() const {
-		return work_file_.c_str();
+		return _work_file.c_str();
 	}
 	void set_work_file(const char *fname);
 
@@ -182,16 +182,16 @@ private:
 
 	qdTriggerProfiler();
 
-	record_container_t records_;
+	record_container_t _records;
 
-	bool is_logging_enabled_;
-	bool is_read_only_;
+	bool _is_logging_enabled;
+	bool _is_read_only;
 
-	std::string work_file_;
+	std::string _work_file;
 
-	static int record_text_format_;
+	static int _record_text_format;
 
-	static const char *const activation_comline_;
+	static const char *const _activation_comline;
 
 
 	static qdTriggerElementPtr get_record_element(const qdTriggerProfilerRecord &rec);

--- a/qdcore/qd_video.cpp
+++ b/qdcore/qd_video.cpp
@@ -35,14 +35,14 @@
 
 namespace QDEngine {
 
-qdVideo::qdVideo() : position_(0, 0) {
+qdVideo::qdVideo() : _position(0, 0) {
 }
 
 qdVideo::qdVideo(const qdVideo &v):
 	qdConditionalObject(v),
-	position_(v.position_),
-	file_name_(v.file_name_),
-	background_(v.background_) {
+	_position(v._position),
+	_file_name(v._file_name),
+	_background(v._background) {
 }
 
 qdVideo::~qdVideo() {
@@ -53,9 +53,9 @@ qdVideo &qdVideo::operator = (const qdVideo &v) {
 
 	*static_cast<qdConditionalObject *>(this) = v;
 
-	position_ = v.position_;
-	file_name_ = v.file_name_;
-	background_ = v.background_;
+	_position = v._position;
+	_file_name = v._file_name;
+	_background = v._background;
 
 	return *this;
 }
@@ -113,13 +113,13 @@ bool qdVideo::save_script(Common::WriteStream &fh, int indent) const {
 		fh.writeString(Common::String::format(" flags=\"%d\"", flags()));
 	}
 
-	if (!check_flag(VID_CENTER_FLAG | VID_FULLSCREEN_FLAG) && (position_.x || position_.y)) {
-		fh.writeString(Common::String::format(" video_position=\"%d %d\"", position_.x, position_.y)) ;
+	if (!check_flag(VID_CENTER_FLAG | VID_FULLSCREEN_FLAG) && (_position.x || _position.y)) {
+		fh.writeString(Common::String::format(" video_position=\"%d %d\"", _position.x, _position.y)) ;
 	}
 
 	fh.writeString(">\r\n");
 
-	if (background_.has_file()) {
+	if (_background.has_file()) {
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
@@ -129,7 +129,7 @@ bool qdVideo::save_script(Common::WriteStream &fh, int indent) const {
 	for (int i = 0; i <= indent; i++) {
 		fh.writeString("\t");
 	}
-	fh.writeString(Common::String::format("<file>%s</file>\r\n", qdscr_XML_string(file_name_.c_str())));
+	fh.writeString(Common::String::format("<file>%s</file>\r\n", qdscr_XML_string(_file_name.c_str())));
 
 	save_conditions_script(fh, indent);
 
@@ -142,16 +142,16 @@ bool qdVideo::save_script(Common::WriteStream &fh, int indent) const {
 }
 
 bool qdVideo::draw_background() {
-	if (background_.has_file()) {
-		background_.load();
+	if (_background.has_file()) {
+		_background.load();
 
 		grDispatcher::instance()->Fill(0);
 		int x = qdGameConfig::get_config().screen_sx() >> 1;
 		int y = qdGameConfig::get_config().screen_sy() >> 1;
-		background_.redraw(x, y, 0);
+		_background.redraw(x, y, 0);
 		grDispatcher::instance()->Flush();
 
-		background_.free();
+		_background.free();
 
 		return true;
 	}
@@ -174,8 +174,8 @@ qdConditionalObject::trigger_start_mode qdVideo::trigger_start() {
 }
 
 bool qdVideo::get_files_list(qdFileNameList &files_to_copy, qdFileNameList &files_to_pack) const {
-	if (!file_name_.empty())
-		files_to_copy.push_back(file_name_);
+	if (!_file_name.empty())
+		files_to_copy.push_back(_file_name);
 
 	if (background_file_name())
 		files_to_pack.push_back(background_file_name());

--- a/qdcore/qd_video.h
+++ b/qdcore/qd_video.h
@@ -56,27 +56,27 @@ public:
 	}
 
 	const char *file_name() const {
-		return file_name_.c_str();
+		return _file_name.c_str();
 	}
 	void set_file_name(const char *fname) {
-		file_name_ = fname;
+		_file_name = fname;
 	}
 
 	// Фон, на котором будет проигрываться видео
 	void set_background_file_name(const char *fname) {
-		background_.set_file(fname);
+		_background.set_file(fname);
 	}
 	const char *background_file_name() const {
-		return background_.file();
+		return _background.file();
 	}
 	bool draw_background();
 
 	// Экранные координаты верхнего левого угла
 	const Vect2s &position() const {
-		return position_;
+		return _position;
 	}
 	void set_position(const Vect2s pos) {
-		position_ = pos;
+		_position = pos;
 	}
 
 	bool load_script(const xml::tag *p);
@@ -92,10 +92,10 @@ public:
 
 private:
 
-	Vect2s position_;
-	std::string file_name_;
+	Vect2s _position;
+	std::string _file_name;
 
-	qdSprite background_;
+	qdSprite _background;
 };
 
 } // namespace QDEngine


### PR DESCRIPTION
This commit involves renaming member variables for the following classes: 
1. parser
3. tag
4. tag_buffer
5. qdAnimationFrame