### PR TITLE
Rename methods to start with lowercase letters

### DIFF
--- a/qd_runtime.cpp
+++ b/qd_runtime.cpp
@@ -353,7 +353,7 @@ void init_graphics() {
 	grDispatcher::instance()->SetClip();
 	grDispatcher::instance()->SetClipMode(1);
 
-	grDispatcher::instance()->Fill(0);
+	grDispatcher::instance()->fill(0);
 
 	g_system->updateScreen();
 

--- a/qd_runtime.cpp
+++ b/qd_runtime.cpp
@@ -350,8 +350,8 @@ void init_graphics() {
 
 	qdGameConfig::get_config().set_pixel_format(grDispatcher::instance()->pixel_format());
 
-	grDispatcher::instance()->SetClip();
-	grDispatcher::instance()->SetClipMode(1);
+	grDispatcher::instance()->setClip();
+	grDispatcher::instance()->setClipMode(1);
 
 	grDispatcher::instance()->fill(0);
 

--- a/qd_runtime.cpp
+++ b/qd_runtime.cpp
@@ -357,7 +357,7 @@ void init_graphics() {
 
 	g_system->updateScreen();
 
-	grDispatcher::instance()->Flush();
+	grDispatcher::instance()->flush();
 }
 
 bool init_graphics_dispatcher() {
@@ -379,7 +379,7 @@ void qd_show_load_progress(int percents_loaded, void *p) {
 
 	grDispatcher::instance()->Rectangle(x, y, rect_sx, rect_sy, 0xFFFFFF, 0, GR_OUTLINED);
 	grDispatcher::instance()->Rectangle(x, y, sx, rect_sy, 0xFFFFFF, 0xFFFFFF, GR_FILLED);
-	grDispatcher::instance()->Flush(x, y, rect_sx, rect_sy);
+	grDispatcher::instance()->flush(x, y, rect_sx, rect_sy);
 }
 
 void restore_graphics() {

--- a/qd_runtime.cpp
+++ b/qd_runtime.cpp
@@ -325,7 +325,7 @@ int engineMain() {
 
 	delete qd_gameD;
 
-	grDispatcher::instance()->Finit();
+	grDispatcher::instance()->finit();
 
 	qdFileManager::instance().Finit();
 
@@ -341,7 +341,7 @@ namespace qdrt {
 
 void init_graphics() {
 	grDispatcher::set_restore_handler(restore_graphics);
-	grDispatcher::instance()->Finit();
+	grDispatcher::instance()->finit();
 
 	grDispatcher::set_instance(grD);
 

--- a/qd_runtime.cpp
+++ b/qd_runtime.cpp
@@ -375,7 +375,7 @@ void qd_show_load_progress(int percents_loaded, void *p) {
 	if (sx > rect_sx) sx = rect_sx;
 
 	int x = 10;
-	int y = grDispatcher::instance()->Get_SizeY() - rect_sy - 10;
+	int y = grDispatcher::instance()->get_SizeY() - rect_sy - 10;
 
 	grDispatcher::instance()->Rectangle(x, y, rect_sx, rect_sy, 0xFFFFFF, 0, GR_OUTLINED);
 	grDispatcher::instance()->Rectangle(x, y, sx, rect_sy, 0xFFFFFF, 0xFFFFFF, GR_FILLED);

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -167,7 +167,7 @@ void qdAnimationSetPreview::set_screen(Vect2s offs, Vect2s size) {
 	_camera->set_scr_size(size.x, size.y);
 	_camera->set_scr_center(offs.x + size.x / 2, offs.y + size.y * 3 / 4);
 
-	_graph_d->SetClip(offs.x, offs.y, offs.x + size.x, offs.y + size.y);
+	_graph_d->setClip(offs.x, offs.y, offs.x + size.x, offs.y + size.y);
 }
 
 void qdAnimationSetPreview::redraw_grid() {

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -92,7 +92,7 @@ void qdAnimationSetPreview::quant(float tm) {
 void qdAnimationSetPreview::redraw() {
 	grDispatcher *gp = grDispatcher::set_instance(_graph_d);
 
-	grDispatcher::instance()->Fill(_back_color);
+	grDispatcher::instance()->fill(_back_color);
 
 	redraw_grid();
 

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -111,7 +111,7 @@ void qdAnimationSetPreview::redraw() {
 	grDispatcher::instance()->Line(v1.x - line_sz, v1.y, v1.x + line_sz, v1.y, _grid_color);
 	grDispatcher::instance()->Line(v0.x, v0.y, v1.x, v1.y, _grid_color);
 	grDispatcher::instance()->Rectangle(_screen_offset.x, _screen_offset.y, _screen_size.x, _screen_size.y, _grid_color, 0, GR_OUTLINED);
-	grDispatcher::instance()->Flush();
+	grDispatcher::instance()->flush();
 
 	grDispatcher::set_instance(gp);
 }

--- a/qdcore/qd_animation_set_preview.cpp
+++ b/qdcore/qd_animation_set_preview.cpp
@@ -62,7 +62,7 @@ qdAnimationSetPreview::~qdAnimationSetPreview() {
 
 void qdAnimationSetPreview::set_graph_dispatcher(grDispatcher *p) {
 	_graph_d = p;
-	set_screen(Vect2s(0, 0), Vect2s(p->Get_SizeX(), p->Get_SizeY()));
+	set_screen(Vect2s(0, 0), Vect2s(p->get_SizeX(), p->get_SizeY()));
 }
 
 void qdAnimationSetPreview::start() {

--- a/qdcore/qd_game_dispatcher.cpp
+++ b/qdcore/qd_game_dispatcher.cpp
@@ -738,14 +738,14 @@ void qdGameDispatcher::redraw() {
 					redraw(*it);
 			}
 
-			grDispatcher::instance()->FlushChanges();
+			grDispatcher::instance()->flushChanges();
 #else
 			redraw(grScreenRegion(grDispatcher::instance()->Get_SizeX() / 2, grDispatcher::instance()->Get_SizeY() / 2, grDispatcher::instance()->Get_SizeX(), grDispatcher::instance()->Get_SizeY()));
 
 			for (grDispatcher::region_iterator it = grDispatcher::instance()->changed_regions().begin(); it != grDispatcher::instance()->changed_regions().end(); ++it)
 				grDispatcher::instance()->Rectangle(it->min_x(), it->min_y(), it->size_x(), it->size_y(), 0xFFFFFF, 0, GR_OUTLINED);
 
-			grDispatcher::instance()->Flush();
+			grDispatcher::instance()->flush();
 #endif
 		}
 		if (!qdGameConfig::get_config().force_full_redraw())

--- a/qdcore/qd_game_dispatcher.cpp
+++ b/qdcore/qd_game_dispatcher.cpp
@@ -699,7 +699,7 @@ void qdGameDispatcher::pre_redraw() {
 			}
 		}
 	} else
-		add_redraw_region(grScreenRegion(grDispatcher::instance()->Get_SizeX() / 2, grDispatcher::instance()->Get_SizeY() / 2, grDispatcher::instance()->Get_SizeX(), grDispatcher::instance()->Get_SizeY()));
+		add_redraw_region(grScreenRegion(grDispatcher::instance()->get_SizeX() / 2, grDispatcher::instance()->get_SizeY() / 2, grDispatcher::instance()->get_SizeX(), grDispatcher::instance()->get_SizeY()));
 
 	grDispatcher::instance()->build_changed_regions();
 }
@@ -740,7 +740,7 @@ void qdGameDispatcher::redraw() {
 
 			grDispatcher::instance()->flushChanges();
 #else
-			redraw(grScreenRegion(grDispatcher::instance()->Get_SizeX() / 2, grDispatcher::instance()->Get_SizeY() / 2, grDispatcher::instance()->Get_SizeX(), grDispatcher::instance()->Get_SizeY()));
+			redraw(grScreenRegion(grDispatcher::instance()->get_SizeX() / 2, grDispatcher::instance()->get_SizeY() / 2, grDispatcher::instance()->get_SizeX(), grDispatcher::instance()->get_SizeY()));
 
 			for (grDispatcher::region_iterator it = grDispatcher::instance()->changed_regions().begin(); it != grDispatcher::instance()->changed_regions().end(); ++it)
 				grDispatcher::instance()->Rectangle(it->min_x(), it->min_y(), it->size_x(), it->size_y(), 0xFFFFFF, 0, GR_OUTLINED);

--- a/qdcore/qd_game_dispatcher.cpp
+++ b/qdcore/qd_game_dispatcher.cpp
@@ -2836,7 +2836,7 @@ bool qdGameDispatcher::game_screenshot(Graphics::Surface &thumb) const {
 		for (int i = 0; i < h; i++) {
 			uint16 *dst = (uint16 *)thumb.getBasePtr(0, i);
 			for (int j = 0; j < w; j++) {
-				grDispatcher::instance()->GetPixel(j, i, col);
+				grDispatcher::instance()->getPixel(j, i, col);
 				*dst = col;
 				dst++;
 			}

--- a/qdcore/qd_game_dispatcher.cpp
+++ b/qdcore/qd_game_dispatcher.cpp
@@ -755,10 +755,10 @@ void qdGameDispatcher::redraw() {
 }
 
 void qdGameDispatcher::redraw(const grScreenRegion &reg) {
-//	grDispatcher::instance()->SetClip(reg.min_x() - 1,reg.min_y() - 1,reg.max_x() + 1,reg.max_y() + 1);
+//	grDispatcher::instance()->setClip(reg.min_x() - 1,reg.min_y() - 1,reg.max_x() + 1,reg.max_y() + 1);
 //	grDispatcher::instance()->Erase(reg.min_x() - 1,reg.min_y() - 1,reg.size_x() + 2,reg.size_y() + 2,0);
 
-	grDispatcher::instance()->SetClip(reg.min_x(), reg.min_y(), reg.max_x(), reg.max_y());
+	grDispatcher::instance()->setClip(reg.min_x(), reg.min_y(), reg.max_x(), reg.max_y());
 	grDispatcher::instance()->Erase(reg.min_x(), reg.min_y(), reg.size_x(), reg.size_y(), 0);
 
 	if (!_interface_dispatcher.is_active()) {
@@ -773,7 +773,7 @@ void qdGameDispatcher::redraw(const grScreenRegion &reg) {
 	debugC(1, kDebugTemp, "_mouse_obj->redraw()");
 	_mouse_obj->redraw();
 
-	grDispatcher::instance()->SetClip();
+	grDispatcher::instance()->setClip();
 }
 
 void qdGameDispatcher::redraw_scene(bool draw_interface) {

--- a/qdcore/qd_game_object_state.cpp
+++ b/qdcore/qd_game_object_state.cpp
@@ -1492,7 +1492,7 @@ bool qdGameObjectStateMask::draw_mask(uint32 color) const {
 	for (int y = 0; y < mask_size().y; y++) {
 		for (int x = 0; x < mask_size().x; x++) {
 			if (hit(pos.x + x, pos.y + y)) {
-				grDispatcher::instance()->SetPixel(pos.x + x, pos.y + y, color);
+				grDispatcher::instance()->setPixel(pos.x + x, pos.y + y, color);
 			}
 		}
 	}

--- a/qdcore/qd_interface_text_window.cpp
+++ b/qdcore/qd_interface_text_window.cpp
@@ -373,10 +373,10 @@ bool qdInterfaceTextWindow::redraw() const {
 	if (_windowType == WINDOW_DIALOGS) {
 		if (_text_set) {
 			int l_clip, t_clip, r_clip, b_clip;
-			grDispatcher::instance()->GetClip(l_clip, t_clip, r_clip, b_clip);
+			grDispatcher::instance()->getClip(l_clip, t_clip, r_clip, b_clip);
 
 			Vect2i ar = r();
-			grDispatcher::instance()->LimitClip(ar.x - _text_size.x / 2, ar.y - _text_size.y / 2, ar.x + _text_size.x / 2, ar.y + _text_size.y / 2);
+			grDispatcher::instance()->limitClip(ar.x - _text_size.x / 2, ar.y - _text_size.y / 2, ar.x + _text_size.x / 2, ar.y + _text_size.y / 2);
 
 			if (_has_background_color) {
 				Vect2i text_r = _text_set->screen_pos();
@@ -390,7 +390,7 @@ bool qdInterfaceTextWindow::redraw() const {
 
 			_text_set->redraw();
 
-			grDispatcher::instance()->SetClip(l_clip, t_clip, r_clip, b_clip);
+			grDispatcher::instance()->setClip(l_clip, t_clip, r_clip, b_clip);
 
 			if (qdGameConfig::get_config().debug_draw())
 				grDispatcher::instance()->Rectangle(ar.x - _text_size.x / 2, ar.y - _text_size.y / 2, _text_size.x, _text_size.y, 0xFFFFFF, 0, GR_OUTLINED, 3);

--- a/qdcore/qd_minigame_interface.cpp
+++ b/qdcore/qd_minigame_interface.cpp
@@ -503,7 +503,7 @@ qdMinigameSceneInterface *qdEngineInterfaceImpl::scene_interface(qdGameScene *sc
 
 mgVect2i qdEngineInterfaceImpl::screen_size() const {
 	if (grDispatcher * dp = grDispatcher::instance())
-		return mgVect2i(dp->Get_SizeX(), dp->Get_SizeY());
+		return mgVect2i(dp->get_SizeX(), dp->get_SizeY());
 
 	return mgVect2i(0, 0);
 }

--- a/qdcore/qd_sprite.cpp
+++ b/qdcore/qd_sprite.cpp
@@ -623,20 +623,20 @@ void qdSprite::redraw(int x, int y, int z, int mode) const {
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSpr_a_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode);
+			grDispatcher::instance()->putSpr_a_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode);
 		else
-			grDispatcher::instance()->PutSpr_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode);
+			grDispatcher::instance()->putSpr_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode);
 	} else
-		grDispatcher::instance()->PutSpr_rle_z(xx, yy, z, _picture_size.x, _picture_size.y, _rle_data, mode, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSpr_rle_z(xx, yy, z, _picture_size.x, _picture_size.y, _rle_data, mode, check_flag(ALPHA_FLAG));
 #else
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSpr_a(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
+			grDispatcher::instance()->putSpr_a(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
 		else
-			grDispatcher::instance()->PutSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
+			grDispatcher::instance()->putSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
 	} else
-		grDispatcher::instance()->PutSpr_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mode, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSpr_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mode, check_flag(ALPHA_FLAG));
 #endif
 
 	if (debugChannelSet(1, kDebugGraphics))
@@ -664,9 +664,9 @@ void qdSprite::redraw_rot(int x, int y, int z, float angle, int mode) const {
 
 	if (!is_compressed()) {
 		if (!_data) return;
-		grDispatcher::instance()->PutSpr_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mode, angle);
+		grDispatcher::instance()->putSpr_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mode, angle);
 	} else
-		grDispatcher::instance()->PutSpr_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mode, angle);
+		grDispatcher::instance()->putSpr_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mode, angle);
 }
 
 void qdSprite::redraw_rot(int x, int y, int z, float angle, const Vect2f &scale, int mode) const {
@@ -693,9 +693,9 @@ void qdSprite::redraw_rot(int x, int y, int z, float angle, const Vect2f &scale,
 
 	if (!is_compressed()) {
 		if (!_data) return;
-		grDispatcher::instance()->PutSpr_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mode, angle, scale);
+		grDispatcher::instance()->putSpr_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mode, angle, scale);
 	} else
-		grDispatcher::instance()->PutSpr_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mode, angle, scale);
+		grDispatcher::instance()->putSpr_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mode, angle, scale);
 }
 
 void qdSprite::redraw(int x, int y, int z, float scale, int mode) const {
@@ -716,20 +716,20 @@ void qdSprite::redraw(int x, int y, int z, float scale, int mode) const {
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSpr_a_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode, scale);
+			grDispatcher::instance()->putSpr_a_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode, scale);
 		else
-			grDispatcher::instance()->PutSpr_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode, scale);
+			grDispatcher::instance()->putSpr_z(xx, yy, z, _picture_size.x, _picture_size.y, _data, mode, scale);
 	} else
-		grDispatcher::instance()->PutSpr_rle_z(xx, yy, z, _picture_size.x, _picture_size.y, _rle_data, mode, scale, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSpr_rle_z(xx, yy, z, _picture_size.x, _picture_size.y, _rle_data, mode, scale, check_flag(ALPHA_FLAG));
 #else
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSpr_a(xx, yy, _picture_size.x, _picture_size.y, _data, mode, scale);
+			grDispatcher::instance()->putSpr_a(xx, yy, _picture_size.x, _picture_size.y, _data, mode, scale);
 		else
-			grDispatcher::instance()->PutSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode, scale);
+			grDispatcher::instance()->putSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode, scale);
 	} else
-		grDispatcher::instance()->PutSpr_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mode, scale, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSpr_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mode, scale, check_flag(ALPHA_FLAG));
 #endif
 }
 
@@ -750,11 +750,11 @@ void qdSprite::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha,
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSprMask_a(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode);
+			grDispatcher::instance()->putSprMask_a(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode);
 		else
-			grDispatcher::instance()->PutSprMask(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode);
+			grDispatcher::instance()->putSprMask(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode);
 	} else
-		grDispatcher::instance()->PutSprMask_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mask_color, mask_alpha, mode, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSprMask_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mask_color, mask_alpha, mode, check_flag(ALPHA_FLAG));
 }
 
 void qdSprite::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha, float scale, int mode) const {
@@ -774,11 +774,11 @@ void qdSprite::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha,
 	if (!is_compressed()) {
 		if (!_data) return;
 		if (check_flag(ALPHA_FLAG))
-			grDispatcher::instance()->PutSprMask_a(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode, scale);
+			grDispatcher::instance()->putSprMask_a(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode, scale);
 		else
-			grDispatcher::instance()->PutSprMask(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode, scale);
+			grDispatcher::instance()->putSprMask(xx, yy, _picture_size.x, _picture_size.y, _data, mask_color, mask_alpha, mode, scale);
 	} else
-		grDispatcher::instance()->PutSprMask_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mask_color, mask_alpha, mode, scale, check_flag(ALPHA_FLAG));
+		grDispatcher::instance()->putSprMask_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mask_color, mask_alpha, mode, scale, check_flag(ALPHA_FLAG));
 }
 
 void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color, int mask_alpha, int mode) const {
@@ -802,9 +802,9 @@ void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color
 
 	if (!is_compressed()) {
 		if (!_data) return;
-		grDispatcher::instance()->PutSprMask_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle);
+		grDispatcher::instance()->putSprMask_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle);
 	} else
-		grDispatcher::instance()->PutSprMask_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle);
+		grDispatcher::instance()->putSprMask_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle);
 }
 
 void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color, int mask_alpha, const Vect2f &scale, int mode) const {
@@ -831,9 +831,9 @@ void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color
 
 	if (!is_compressed()) {
 		if (!_data) return;
-		grDispatcher::instance()->PutSprMask_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle, scale);
+		grDispatcher::instance()->putSprMask_rot(Vect2i(xx, yy), _picture_size, _data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle, scale);
 	} else
-		grDispatcher::instance()->PutSprMask_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle, scale);
+		grDispatcher::instance()->putSprMask_rle_rot(Vect2i(xx, yy), _picture_size, _rle_data, check_flag(ALPHA_FLAG), mask_color, mask_alpha, mode, angle, scale);
 }
 
 void qdSprite::draw_contour(int x, int y, uint32 color, int mode) const {

--- a/qdcore/qd_video.cpp
+++ b/qdcore/qd_video.cpp
@@ -149,7 +149,7 @@ bool qdVideo::draw_background() {
 		int x = qdGameConfig::get_config().screen_sx() >> 1;
 		int y = qdGameConfig::get_config().screen_sy() >> 1;
 		_background.redraw(x, y, 0);
-		grDispatcher::instance()->Flush();
+		grDispatcher::instance()->flush();
 
 		_background.free();
 
@@ -157,7 +157,7 @@ bool qdVideo::draw_background() {
 	}
 
 	grDispatcher::instance()->fill(0);
-	grDispatcher::instance()->Flush();
+	grDispatcher::instance()->flush();
 
 	return false;
 }

--- a/qdcore/qd_video.cpp
+++ b/qdcore/qd_video.cpp
@@ -145,7 +145,7 @@ bool qdVideo::draw_background() {
 	if (_background.has_file()) {
 		_background.load();
 
-		grDispatcher::instance()->Fill(0);
+		grDispatcher::instance()->fill(0);
 		int x = qdGameConfig::get_config().screen_sx() >> 1;
 		int y = qdGameConfig::get_config().screen_sy() >> 1;
 		_background.redraw(x, y, 0);
@@ -156,7 +156,7 @@ bool qdVideo::draw_background() {
 		return true;
 	}
 
-	grDispatcher::instance()->Fill(0);
+	grDispatcher::instance()->fill(0);
 	grDispatcher::instance()->Flush();
 
 	return false;

--- a/system/graphics/gr_dispatcher.cpp
+++ b/system/graphics/gr_dispatcher.cpp
@@ -160,7 +160,7 @@ void grDispatcher::fill(int val) {
 	_screenBuf->clear(val);
 }
 
-bool grDispatcher::Flush(int x, int y, int sx, int sy) {
+bool grDispatcher::flush(int x, int y, int sx, int sy) {
 	int x1 = x + sx;
 	int y1 = y + sy;
 
@@ -175,15 +175,15 @@ bool grDispatcher::Flush(int x, int y, int sx, int sy) {
 	if (y1 > _sizeY)
 		y1 = _sizeY;
 
-	debugC(8, kDebugGraphics, "grDispatcher::Flush(%d, %d, %d, %d)", x, y, x1 - x, y1 - y);
+	debugC(8, kDebugGraphics, "grDispatcher::flush(%d, %d, %d, %d)", x, y, x1 - x, y1 - y);
 
 	g_system->copyRectToScreen(_screenBuf->getBasePtr(x, y), _screenBuf->pitch, x, y, x1 - x, y1 - y);
 
 	return true;
 }
 
-bool grDispatcher::Flush() {
-	return Flush(0, 0, _sizeX, _sizeY);
+bool grDispatcher::flush() {
+	return flush(0, 0, _sizeX, _sizeY);
 }
 
 void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style, bool inverse_col) {
@@ -733,9 +733,9 @@ bool grDispatcher::invalidate_region(const grScreenRegion &reg) {
 	return true;
 }
 
-bool grDispatcher::FlushChanges() {
+bool grDispatcher::flushChanges() {
 	for (regions_container_t::const_iterator it = _changed_regions.begin(); it != _changed_regions.end(); ++it)
-		Flush(it->min_x() - 1, it->min_y() - 1, it->size_x() + 2, it->size_y() + 2);
+		flush(it->min_x() - 1, it->min_y() - 1, it->size_x() + 2, it->size_y() + 2);
 
 	return true;
 }

--- a/system/graphics/gr_dispatcher.cpp
+++ b/system/graphics/gr_dispatcher.cpp
@@ -156,7 +156,7 @@ bool grDispatcher::init(int sx, int sy, grPixelFormat pixel_format) {
 	return true;
 }
 
-void grDispatcher::Fill(int val) {
+void grDispatcher::fill(int val) {
 	_screenBuf->clear(val);
 }
 

--- a/system/graphics/gr_dispatcher.cpp
+++ b/system/graphics/gr_dispatcher.cpp
@@ -107,12 +107,12 @@ grDispatcher::grDispatcher() : _screenBuf(NULL),
 }
 
 grDispatcher::~grDispatcher() {
-	Finit();
+	finit();
 
 	if (_dispatcher_ptr == this) _dispatcher_ptr = 0;
 }
 
-bool grDispatcher::Finit() {
+bool grDispatcher::finit() {
 #ifdef _GR_ENABLE_ZBUFFER
 	free_zbuffer();
 #endif
@@ -130,7 +130,7 @@ bool grDispatcher::Finit() {
 }
 
 bool grDispatcher::init(int sx, int sy, grPixelFormat pixel_format) {
-	Finit();
+	finit();
 
 	_pixel_format = pixel_format;
 

--- a/system/graphics/gr_dispatcher.cpp
+++ b/system/graphics/gr_dispatcher.cpp
@@ -193,7 +193,7 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 
 	if (!inverse_col) {
 		if (x1 == x2 && y1 == y2) {
-			SetPixelFast(x1, y1, col);
+			setPixelFast(x1, y1, col);
 			return;
 		}
 
@@ -212,7 +212,7 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 			}
 			do {
 				if (++v > line_style) {
-					SetPixelFast(x, y >> F_PREC, col);
+					setPixelFast(x, y >> F_PREC, col);
 					if (v >= line_style * 2)
 						v = 0;
 				}
@@ -234,7 +234,7 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 			}
 			do {
 				if (++v > line_style) {
-					SetPixelFast(x >> F_PREC, y, col);
+					setPixelFast(x >> F_PREC, y, col);
 					if (v >= line_style * 2)
 						v = 0;
 				}
@@ -244,7 +244,7 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 		}
 	} else {
 		if (x1 == x2 && y1 == y2) {
-			SetPixelFast(x1, y1, col);
+			setPixelFast(x1, y1, col);
 			return;
 		}
 
@@ -263,11 +263,11 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 			}
 			do {
 				if (++v > line_style) {
-					SetPixelFast(x, y >> F_PREC, col);
+					setPixelFast(x, y >> F_PREC, col);
 					if (v >= line_style * 2)
 						v = 0;
 				} else
-					SetPixelFast(x, y >> F_PREC, ~col);
+					setPixelFast(x, y >> F_PREC, ~col);
 
 				x += incr;
 				y += k;
@@ -287,11 +287,11 @@ void grDispatcher::Line(int x1, int y1, int x2, int y2, int col, int line_style,
 			}
 			do {
 				if (++v > line_style) {
-					SetPixelFast(x >> F_PREC, y, col);
+					setPixelFast(x >> F_PREC, y, col);
 					if (v >= line_style * 2)
 						v = 0;
 				} else
-					SetPixelFast(x >> F_PREC, y, ~col);
+					setPixelFast(x >> F_PREC, y, ~col);
 
 				y += incr;
 				x += k;
@@ -383,35 +383,35 @@ void grDispatcher::Erase(int x, int y, int sx, int sy, int col) {
 	return;
 }
 
-void grDispatcher::SetPixel(int x, int y, int col) {
+void grDispatcher::setPixel(int x, int y, int col) {
 	if (_clipMode && !clipCheck(x, y)) return;
 
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
 	*p = col;
 }
 
-void grDispatcher::SetPixelFast(int x, int y, int col) {
+void grDispatcher::setPixelFast(int x, int y, int col) {
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
 	*p = col;
 }
 
-void grDispatcher::SetPixelFast(int x, int y, int r, int g, int b) {
+void grDispatcher::setPixelFast(int x, int y, int r, int g, int b) {
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
 	*p = (((r >> 3) << 11) + ((g >> 2) << 5) + ((b >> 3) << 0));
 }
 
-void grDispatcher::SetPixel(int x, int y, int r, int g, int b) {
+void grDispatcher::setPixel(int x, int y, int r, int g, int b) {
 	if (_clipMode && !clipCheck(x, y)) return;
 
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x * 2, y));
 	*p = (((r >> 3) << 11) + ((g >> 2) << 5) + ((b >> 3) << 0));
 }
 
-void grDispatcher::GetPixel(int x, int y, uint16 &col) {
+void grDispatcher::getPixel(int x, int y, uint16 &col) {
 	col = *(uint16 *)(_screenBuf->getBasePtr(x, y));
 }
 
-void grDispatcher::GetPixel(int x, int y, byte &r, byte &g, byte &b) {
+void grDispatcher::getPixel(int x, int y, byte &r, byte &g, byte &b) {
 	uint16 col = *(uint16 *)(_screenBuf->getBasePtr(x, y));
 	split_rgb565u(col, r, g, b);
 }
@@ -539,7 +539,7 @@ void grDispatcher::Line_z(int x1, int y1, int z1, int x2, int y2, int z2, int co
 	if (x1 == x2 && y1 == y2) {
 		int z = (z1 < z2) ? z1 : z2;
 		if (get_z(x1, y1) > z)
-			SetPixelFast(x1, y1, col);
+			setPixelFast(x1, y1, col);
 		return;
 	}
 
@@ -564,7 +564,7 @@ void grDispatcher::Line_z(int x1, int y1, int z1, int x2, int y2, int z2, int co
 		do {
 			if (++v > line_style) {
 				if (get_z(x, y >> F_PREC) >= (z >> F_PREC))
-					SetPixelFast(x, y >> F_PREC, col);
+					setPixelFast(x, y >> F_PREC, col);
 				v = 0;
 			}
 			x += incr;
@@ -591,7 +591,7 @@ void grDispatcher::Line_z(int x1, int y1, int z1, int x2, int y2, int z2, int co
 		do {
 			if (++v > line_style) {
 				if (get_z(x >> F_PREC, y) >= (z >> F_PREC))
-					SetPixelFast(x >> F_PREC, y, col);
+					setPixelFast(x >> F_PREC, y, col);
 				v = 0;
 			}
 			y += incr;

--- a/system/graphics/gr_dispatcher.cpp
+++ b/system/graphics/gr_dispatcher.cpp
@@ -384,7 +384,7 @@ void grDispatcher::Erase(int x, int y, int sx, int sy, int col) {
 }
 
 void grDispatcher::SetPixel(int x, int y, int col) {
-	if (_clipMode && !ClipCheck(x, y)) return;
+	if (_clipMode && !clipCheck(x, y)) return;
 
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x, y));
 	*p = col;
@@ -401,7 +401,7 @@ void grDispatcher::SetPixelFast(int x, int y, int r, int g, int b) {
 }
 
 void grDispatcher::SetPixel(int x, int y, int r, int g, int b) {
-	if (_clipMode && !ClipCheck(x, y)) return;
+	if (_clipMode && !clipCheck(x, y)) return;
 
 	uint16 *p = (uint16 *)(_screenBuf->getBasePtr(x * 2, y));
 	*p = (((r >> 3) << 11) + ((g >> 2) << 5) + ((b >> 3) << 0));

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -120,25 +120,25 @@ public:
 		return _sizeY;
 	}
 
-	void SetClipMode(int m) {
+	void setClipMode(int m) {
 		_clipMode = m;
 	}
-	int GetClipMode() const {
+	int getClipMode() const {
 		return _clipMode;
 	}
 
-	void SetClip() {
-		SetClip(0, 0, _sizeX, _sizeY);
+	void setClip() {
+		setClip(0, 0, _sizeX, _sizeY);
 	}
 
-	void GetClip(int &l, int &t, int &r, int &b) const {
+	void getClip(int &l, int &t, int &r, int &b) const {
 		l = _clipCoords[GR_LEFT];
 		t = _clipCoords[GR_TOP];
 		r = _clipCoords[GR_RIGHT];
 		b = _clipCoords[GR_BOTTOM];
 	}
 
-	void SetClip(int l, int t, int r, int b) {
+	void setClip(int l, int t, int r, int b) {
 		if (l < 0) l = 0;
 		if (r > _sizeX) r = _sizeX;
 
@@ -151,21 +151,21 @@ public:
 		_clipCoords[GR_BOTTOM] = b;
 	}
 
-	void LimitClip(int l, int t, int r, int b) {
+	void limitClip(int l, int t, int r, int b) {
 		if (_clipCoords[GR_LEFT] < l) _clipCoords[GR_LEFT] = l;
 		if (_clipCoords[GR_TOP] < t) _clipCoords[GR_TOP] = t;
 		if (_clipCoords[GR_RIGHT] > r) _clipCoords[GR_RIGHT] = r;
 		if (_clipCoords[GR_BOTTOM] > b) _clipCoords[GR_BOTTOM] = b;
 	}
 
-	int ClipCheck(int x, int y) {
+	int clipCheck(int x, int y) {
 		if (x >= _clipCoords[GR_LEFT] && x < _clipCoords[GR_RIGHT] && y >= _clipCoords[GR_TOP] && y < _clipCoords[GR_BOTTOM])
 			return 1;
 
 		return 0;
 	}
 
-	int ClipCheck(int x, int y, int sx, int sy) {
+	int clipCheck(int x, int y, int sx, int sy) {
 		if (x - sx >= _clipCoords[GR_LEFT] && x + sx < _clipCoords[GR_RIGHT] && y - sy >= _clipCoords[GR_TOP] && y + sy < _clipCoords[GR_BOTTOM])
 			return 1;
 

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -173,9 +173,9 @@ public:
 	}
 
 
-	bool Flush(int x, int y, int sx, int sy);
-	bool Flush();
-	bool FlushChanges();
+	bool flush(int x, int y, int sx, int sy);
+	bool flush();
+	bool flushChanges();
 
 	void fill(int val);
 

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -113,10 +113,10 @@ public:
 	void *Get_hWnd() const {
 		return _hWnd;
 	}
-	int Get_SizeX() const {
+	int get_SizeX() const {
 		return _sizeX;
 	}
-	int Get_SizeY() const {
+	int get_SizeY() const {
 		return _sizeY;
 	}
 

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -40,7 +40,7 @@ enum GR_LINEDIR {
 	GR_BOTTOM
 };
 
-// Modes for PutSpr()
+// Modes for putSpr()
 const int GR_BLACK_FON      = 0x01;
 const int GR_CLIPPED        = 0x02;
 const int GR_NOCLIP     = 0x04;
@@ -179,29 +179,29 @@ public:
 
 	void fill(int val);
 
-	void PutSpr(int x, int y, int sx, int sy, const byte *p, int mode);
-	void PutSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale);
-	void PutSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, bool alpha_flag);
-	void PutSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, float scale, bool alpha_flag);
-	void PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mode);
-	void PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mode, float scale);
+	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode);
+	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale);
+	void putSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, bool alpha_flag);
+	void putSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, float scale, bool alpha_flag);
+	void putSpr_a(int x, int y, int sx, int sy, const byte *p, int mode);
+	void putSpr_a(int x, int y, int sx, int sy, const byte *p, int mode, float scale);
 
-	void PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle);
-	void PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle, const Vect2f &scale);
-	void PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle);
-	void PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle, const Vect2f &scale);
+	void putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle);
+	void putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle, const Vect2f &scale);
+	void putSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle);
+	void putSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle, const Vect2f &scale);
 
-	void PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle);
-	void PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale);
-	void PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle);
-	void PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale);
+	void putSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle);
+	void putSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale);
+	void putSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle);
+	void putSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale);
 
-	void PutSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode);
-	void PutSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale);
-	void PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, bool alpha_flag);
-	void PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, float scale, bool alpha_flag);
-	void PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode);
-	void PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale);
+	void putSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode);
+	void putSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale);
+	void putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, bool alpha_flag);
+	void putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, float scale, bool alpha_flag);
+	void putSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode);
+	void putSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale);
 
 	void PutTileSpr(int x, int y, const grTileSprite &sprite, bool has_alpha, int mode);
 
@@ -221,12 +221,12 @@ public:
 	int TextHeight(const char *str, int vspace = 0, const grFont *font = NULL) const;
 
 #ifdef _GR_ENABLE_ZBUFFER
-	void PutSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode);
-	void PutSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale);
-	void PutSpr_rle_z(int x, int y, int z, int sx, int sy, const rleBuffer *p, int mode, bool alpha_flag);
-	void PutSpr_rle_z(int x, int y, int z, int sx, int sy, const rleBuffer *p, int mode, float scale, bool alpha_flag);
-	void PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode);
-	void PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale);
+	void putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode);
+	void putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale);
+	void putSpr_rle_z(int x, int y, int z, int sx, int sy, const rleBuffer *p, int mode, bool alpha_flag);
+	void putSpr_rle_z(int x, int y, int z, int sx, int sy, const rleBuffer *p, int mode, float scale, bool alpha_flag);
+	void putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode);
+	void putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale);
 #endif
 
 	void Erase(int x, int y, int sx, int sy, int col);
@@ -571,7 +571,7 @@ private:
 	static grDispatcher *_dispatcher_ptr;
 	static char *_wnd_class_name;
 
-	void PutSpr_rot90(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle);
+	void putSpr_rot90(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle);
 };
 
 } // namespace QDEngine

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -177,7 +177,7 @@ public:
 	bool Flush();
 	bool FlushChanges();
 
-	void Fill(int val);
+	void fill(int val);
 
 	void PutSpr(int x, int y, int sx, int sy, const byte *p, int mode);
 	void PutSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale);

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -232,14 +232,14 @@ public:
 	void Erase(int x, int y, int sx, int sy, int col);
 	void Erase(int x, int y, int sx, int sy, int r, int g, int b);
 
-	void SetPixel(int x, int y, int col);
-	void SetPixelFast(int x, int y, int col);
-	void SetPixelFast(int x, int y, int r, int g, int b);
+	void setPixel(int x, int y, int col);
+	void setPixelFast(int x, int y, int col);
+	void setPixelFast(int x, int y, int r, int g, int b);
 
-	void SetPixel(int x, int y, int r, int g, int b);
+	void setPixel(int x, int y, int r, int g, int b);
 
-	void GetPixel(int x, int y, uint16 &col);
-	void GetPixel(int x, int y, byte &r, byte &g, byte &b);
+	void getPixel(int x, int y, uint16 &col);
+	void getPixel(int x, int y, byte &r, byte &g, byte &b);
 
 	void Line(int x1, int y1, int x2, int y2, int col, int line_style = 0, bool inverse_col = false);
 

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -108,7 +108,7 @@ public:
 		return false;
 	}
 
-	virtual bool Finit();
+	virtual bool finit();
 
 	void *Get_hWnd() const {
 		return _hWnd;

--- a/system/graphics/gr_draw_sprite.cpp
+++ b/system/graphics/gr_draw_sprite.cpp
@@ -76,7 +76,7 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 			const byte *src_data = line_src + (fx >> 16) * 4;
 			uint32 a = src_data[3];
 
-			if (a != 255 && ClipCheck(x + j, y + i)) {
+			if (a != 255 && clipCheck(x + j, y + i)) {
 				if (a) {
 					uint16 sc;
 					GetPixel(x + j, y + i, sc);
@@ -1213,7 +1213,7 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 			const byte *src_data = line_src + (fx >> 16) * 4;
 			uint32 a = src_data[3];
 
-			if (a != 255 && ClipCheck(x + j, y + i)) {
+			if (a != 255 && clipCheck(x + j, y + i)) {
 				uint16 sc;
 				GetPixel(x + j, y + i, sc);
 

--- a/system/graphics/gr_draw_sprite.cpp
+++ b/system/graphics/gr_draw_sprite.cpp
@@ -30,8 +30,8 @@
 
 namespace QDEngine {
 
-void grDispatcher::PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mode, float scale) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr_a(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
+void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mode, float scale) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr_a(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
 
 	int i, j, sx_dest, sy_dest;
 
@@ -89,8 +89,8 @@ void grDispatcher::PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 	}
 }
 
-void grDispatcher::PutSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
+void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
 
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
@@ -139,8 +139,8 @@ void grDispatcher::PutSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 	return;
 }
 
-void grDispatcher::PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mode) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr_a(%d, %d, %d, %d)", x, y, sx, sy);
+void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mode) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr_a(%d, %d, %d, %d)", x, y, sx, sy);
 
 	int px = 0;
 	int py = 0;
@@ -190,7 +190,7 @@ void grDispatcher::PutSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 	return;
 }
 
-void grDispatcher::PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle) {
+void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle) {
 	const int F_PREC = 16;
 
 	int xc = pos.x + size.x / 2;
@@ -295,7 +295,7 @@ void grDispatcher::PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	}
 }
 
-void grDispatcher::PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle, const Vect2f &scale) {
+void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, int mode, float angle, const Vect2f &scale) {
 	const int F_PREC = 16;
 
 	int xc = pos.x + round(float(size.x) * scale.x / 2.f);
@@ -383,7 +383,7 @@ void grDispatcher::PutSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	}
 }
 
-void grDispatcher::PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle) {
+void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle) {
 	const int F_PREC = 16;
 
 	int xc = pos.x + size.x / 2;
@@ -488,7 +488,7 @@ void grDispatcher::PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	}
 }
 
-void grDispatcher::PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale) {
+void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const byte *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale) {
 	const int F_PREC = 16;
 
 	int xc = pos.x + round(float(size.x) * scale.x / 2.f);
@@ -591,8 +591,8 @@ void grDispatcher::PutSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	}
 }
 
-void grDispatcher::PutSpr(int x, int y, int sx, int sy, const byte *p, int mode) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr(%d, %d, %d, %d)", x, y, sx, sy);
+void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr(%d, %d, %d, %d)", x, y, sx, sy);
 
 	int px = 0;
 	int py = 0;
@@ -991,7 +991,7 @@ void grDispatcher::PutChar(int x, int y, uint32 color, int font_sx, int font_sy,
 	return;
 }
 
-void grDispatcher::PutSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode) {
+void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode) {
 	int px = 0;
 	int py = 0;
 
@@ -1030,7 +1030,7 @@ void grDispatcher::PutSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 
 	uint32 mcl = make_rgb565u(mr, mg, mb);
 
-	warning("STUB: grDispatcher::PutSprMask");
+	warning("STUB: grDispatcher::putSprMask");
 	for (int i = 0; i < psy; i++) {
 		uint16 *scr_buf = (uint16 *)(_screenBuf->getBasePtr(x, y));
 		const byte *data_line = data_ptr;
@@ -1047,7 +1047,7 @@ void grDispatcher::PutSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 	}
 }
 
-void grDispatcher::PutSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale) {
+void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale) {
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
 
@@ -1107,7 +1107,7 @@ void grDispatcher::PutSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 	}
 }
 
-void grDispatcher::PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode) {
+void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode) {
 	int px = 0;
 	int py = 0;
 
@@ -1139,7 +1139,7 @@ void grDispatcher::PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 	byte mr, mg, mb;
 	split_rgb565u(mask_color, mr, mg, mb);
 
-	warning("STUB: grDispatcher::PutSprMask_a");
+	warning("STUB: grDispatcher::putSprMask_a");
 	for (int i = 0; i < psy; i++) {
 		uint16 *scr_buf = (uint16 *)(_screenBuf->getBasePtr(x, y));
 		const byte *data_line = data_ptr;
@@ -1166,7 +1166,7 @@ void grDispatcher::PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 	}
 }
 
-void grDispatcher::PutSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale) {
+void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale) {
 	int i, j, sx_dest, sy_dest;
 
 	sx_dest = round(float(sx) * scale);

--- a/system/graphics/gr_draw_sprite.cpp
+++ b/system/graphics/gr_draw_sprite.cpp
@@ -79,10 +79,10 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 			if (a != 255 && clipCheck(x + j, y + i)) {
 				if (a) {
 					uint16 sc;
-					GetPixel(x + j, y + i, sc);
-					SetPixel(x + j, y + i, alpha_blend_565(make_rgb565u(src_data[2], src_data[1], src_data[0]), sc, a));
+					getPixel(x + j, y + i, sc);
+					setPixel(x + j, y + i, alpha_blend_565(make_rgb565u(src_data[2], src_data[1], src_data[0]), sc, a));
 				} else
-					SetPixel(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
+					setPixel(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
 			}
 			fx += dx;
 		}
@@ -132,7 +132,7 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode,
 		for (int j = x0; j != x1; j += ix) {
 			uint32 cl = line_src[fx >> 16];
 			if (cl)
-				SetPixel(x + j, y + i, cl);
+				setPixel(x + j, y + i, cl);
 			fx += dx;
 		}
 	}
@@ -686,17 +686,17 @@ void grDispatcher::DrawSprContour_a(int x, int y, int sx, int sy, const byte *p,
 		for (int j = 0; j < psx; j++) {
 			if (pic_buf[jj * 2 + 1] < 200) {
 				if (empty_pixel)
-					SetPixelFast(x + j, y + i, contour_color);
+					setPixelFast(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixelFast(x + j - 1, y + i, contour_color);
+					setPixelFast(x + j - 1, y + i, contour_color);
 				empty_pixel = 1;
 			}
 			jj += dpx;
 		}
 		if (!empty_pixel)
-			SetPixelFast(x + psx - 1, y + i, contour_color);
+			setPixelFast(x + psx - 1, y + i, contour_color);
 		pic_buf += dpy;
 	}
 	int jj = px;
@@ -706,17 +706,17 @@ void grDispatcher::DrawSprContour_a(int x, int y, int sx, int sy, const byte *p,
 		for (int i = 0; i < psy; i++) {
 			if (pic_buf[jj * 2 + 1] < 200) {
 				if (empty_pixel)
-					SetPixelFast(x + j, y + i, contour_color);
+					setPixelFast(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixelFast(x + j, y + i - 1, contour_color);
+					setPixelFast(x + j, y + i - 1, contour_color);
 				empty_pixel = 1;
 			}
 			pic_buf += dpy;
 		}
 		if (!empty_pixel)
-			SetPixelFast(x + j, y + psy - 1, contour_color);
+			setPixelFast(x + j, y + psy - 1, contour_color);
 		jj += dpx;
 	}
 	return;
@@ -752,17 +752,17 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const byte *p, i
 			uint32 cl = pic_buf[jj];
 			if (cl) {
 				if (empty_pixel)
-					SetPixelFast(x + j, y + i, contour_color);
+					setPixelFast(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixelFast(x + j - 1, y + i, contour_color);
+					setPixelFast(x + j - 1, y + i, contour_color);
 				empty_pixel = 1;
 			}
 			jj += dpx;
 		}
 		if (!empty_pixel)
-			SetPixelFast(x + psx - 1, y + i, contour_color);
+			setPixelFast(x + psx - 1, y + i, contour_color);
 		pic_buf += dpy;
 	}
 	int jj = px;
@@ -773,17 +773,17 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const byte *p, i
 			uint32 cl = pic_buf[jj];
 			if (cl) {
 				if (empty_pixel)
-					SetPixelFast(x + j, y + i, contour_color);
+					setPixelFast(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixelFast(x + j, y + i - 1, contour_color);
+					setPixelFast(x + j, y + i - 1, contour_color);
 				empty_pixel = 1;
 			}
 			pic_buf += dpy;
 		}
 		if (!empty_pixel)
-			SetPixelFast(x + j, y + psy - 1, contour_color);
+			setPixelFast(x + j, y + psy - 1, contour_color);
 		jj += dpx;
 	}
 	return;
@@ -831,17 +831,17 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const byte *p, i
 		for (int j = x0; j != x1; j += ix) {
 			if (line_src[fx >> 16]) {
 				if (empty_pixel)
-					SetPixel(x + j, y + i, contour_color);
+					setPixel(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixel(x + j - 1, y + i, contour_color);
+					setPixel(x + j - 1, y + i, contour_color);
 				empty_pixel = 1;
 			}
 			fx += dx;
 		}
 		if (!empty_pixel)
-			SetPixel(x + x1 - 1, y + i, contour_color);
+			setPixel(x + x1 - 1, y + i, contour_color);
 	}
 	fx = (1 << 15);
 	for (int j = x0; j != x1; j += ix) {
@@ -853,17 +853,17 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const byte *p, i
 
 			if (line_src[fx >> 16]) {
 				if (empty_pixel)
-					SetPixel(x + j, y + i, contour_color);
+					setPixel(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixel(x + j, y + i - 1, contour_color);
+					setPixel(x + j, y + i - 1, contour_color);
 				empty_pixel = 1;
 			}
 			fy += dy;
 		}
 		if (!empty_pixel)
-			SetPixel(x + j, y + y1 - 1, contour_color);
+			setPixel(x + j, y + y1 - 1, contour_color);
 
 		fx += dx;
 	}
@@ -914,17 +914,17 @@ void grDispatcher::DrawSprContour_a(int x, int y, int sx, int sy, const byte *p,
 		for (int j = x0; j != x1; j += ix) {
 			if (line_src[((fx >> 16) << 1) + 1] < 200) {
 				if (empty_pixel)
-					SetPixel(x + j, y + i, contour_color);
+					setPixel(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixel(x + j - 1, y + i, contour_color);
+					setPixel(x + j - 1, y + i, contour_color);
 				empty_pixel = 1;
 			}
 			fx += dx;
 		}
 		if (!empty_pixel)
-			SetPixel(x + x1 - 1, y + i, contour_color);
+			setPixel(x + x1 - 1, y + i, contour_color);
 	}
 
 	fx = (1 << 15);
@@ -937,17 +937,17 @@ void grDispatcher::DrawSprContour_a(int x, int y, int sx, int sy, const byte *p,
 
 			if (line_src[((fx >> 16) << 1) + 1] < 200) {
 				if (empty_pixel)
-					SetPixel(x + j, y + i, contour_color);
+					setPixel(x + j, y + i, contour_color);
 				empty_pixel = 0;
 			} else {
 				if (!empty_pixel)
-					SetPixel(x + j, y + i - 1, contour_color);
+					setPixel(x + j, y + i - 1, contour_color);
 				empty_pixel = 1;
 			}
 			fy += dy;
 		}
 		if (!empty_pixel)
-			SetPixel(x + j, y + y1 - 1, contour_color);
+			setPixel(x + j, y + y1 - 1, contour_color);
 
 		fx += dx;
 	}
@@ -1099,8 +1099,8 @@ void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 			const byte *src_data = line_src + (fx >> 16) * 3;
 			if (src_data[0] || src_data[1] || src_data[2]) {
 				uint16 scl;
-				GetPixel(x + j, y + i, scl);
-				SetPixel(x + j, y + i, alpha_blend_565(mcl, scl, mask_alpha));
+				getPixel(x + j, y + i, scl);
+				setPixel(x + j, y + i, alpha_blend_565(mcl, scl, mask_alpha));
 			}
 			fx += dx;
 		}
@@ -1215,7 +1215,7 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 
 			if (a != 255 && clipCheck(x + j, y + i)) {
 				uint16 sc;
-				GetPixel(x + j, y + i, sc);
+				getPixel(x + j, y + i, sc);
 
 				a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
@@ -1225,7 +1225,7 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 
 				uint32 cl = make_rgb565u(r, g, b);
 
-				SetPixel(x + j, y + i, alpha_blend_565(cl, sc, a));
+				setPixel(x + j, y + i, alpha_blend_565(cl, sc, a));
 			}
 			fx += dx;
 		}

--- a/system/graphics/gr_draw_sprite_rle.cpp
+++ b/system/graphics/gr_draw_sprite_rle.cpp
@@ -200,7 +200,7 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 				if (clipCheck(x + j, y + i)) {
 					const byte *src_data = line_src + (fx >> 16) * 3;
 					if (src_data[0] || src_data[1] || src_data[2])
-						SetPixelFast(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
+						setPixelFast(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
 				}
 				fx += dx;
 			}
@@ -223,11 +223,11 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 
 						if (a) {
 							uint16 scl;
-							GetPixel(x + j, y + i, scl);
+							getPixel(x + j, y + i, scl);
 
-							SetPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
+							setPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
 						} else
-							SetPixelFast(x + j, y + i, cl);
+							setPixelFast(x + j, y + i, cl);
 					}
 				}
 				fx += dx;
@@ -445,8 +445,8 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 					const byte *src_buf = line_src + ((fx >> 16) << 2);
 					if (src_buf[0] || src_buf[1] || src_buf[2]) {
 						uint16 scl;
-						GetPixel(x + j, y + i, scl);
-						SetPixelFast(x + j, y + i, alpha_blend_565(mcl, scl, mask_alpha));
+						getPixel(x + j, y + i, scl);
+						setPixelFast(x + j, y + i, alpha_blend_565(mcl, scl, mask_alpha));
 					}
 				}
 				fx += dx;
@@ -469,7 +469,7 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 					uint32 a = src_buf[3];
 					if (a != 255) {
 						uint16 scl;
-						GetPixel(x + j, y + i, scl);
+						getPixel(x + j, y + i, scl);
 
 						a = mask_alpha + ((a * (255 - mask_alpha)) >> 8);
 
@@ -479,7 +479,7 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 
 						uint32 cl = make_rgb565u(r, g, b);
 
-						SetPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
+						setPixelFast(x + j, y + i, alpha_blend_565(cl, scl, a));
 					}
 				}
 				fx += dx;
@@ -751,27 +751,27 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const class rleB
 				if (clipCheck(x + j, y + i)) {
 					cl = line_src[(fx >> 16) << 1];
 					if (!cl && j != x0 && line_src[((fx - dx) >> 16) << 1])
-						SetPixel(x + j - ix, y + i, contour_color);
+						setPixel(x + j - ix, y + i, contour_color);
 
 					if (cl && (j == x0 || !line_src[((fx - dx) >> 16) << 1])) {
-						SetPixelFast(x + j, y + i, contour_color);
+						setPixelFast(x + j, y + i, contour_color);
 					} else {
 						if (cl && (i == y0 || !line_src_prev[(fx >> 16) << 1]))
-							SetPixelFast(x + j, y + i, contour_color);
+							setPixelFast(x + j, y + i, contour_color);
 					}
 
 					if (!cl && i != y0 && line_src_prev[(fx >> 16) << 1])
-						SetPixel(x + j, y + i - iy, contour_color);
+						setPixel(x + j, y + i - iy, contour_color);
 				}
 				fx += dx;
 			}
-			if (cl) SetPixel(x + x1 - ix, y + i, contour_color);
+			if (cl) setPixel(x + x1 - ix, y + i, contour_color);
 		}
 		fx = (1 << 15);
 		for (int j = x0; j != x1; j += ix) {
 			const uint16 *line_src_prev = (y1 & 1) ? line0 : line1;
 			if (line_src_prev[(fx >> 16) << 1])
-				SetPixel(x + j, y + y1 - iy, contour_color);
+				setPixel(x + j, y + y1 - iy, contour_color);
 			fx += dx;
 		}
 	} else {
@@ -791,27 +791,27 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const class rleB
 				if (clipCheck(x + j, y + i)) {
 					cl = rle_alpha_b16(line_src[((fx >> 16) << 1) + 1]);
 					if (!cl && j != x0 && rle_alpha_b16(line_src[(((fx - dx) >> 16) << 1) + 1]))
-						SetPixel(x + j - ix, y + i, contour_color);
+						setPixel(x + j - ix, y + i, contour_color);
 
 					if (cl && (j == x0 || !rle_alpha_b16(line_src[(((fx - dx) >> 16) << 1) + 1]))) {
-						SetPixelFast(x + j, y + i, contour_color);
+						setPixelFast(x + j, y + i, contour_color);
 					} else {
 						if (cl && (i == y0 || !rle_alpha_b16(line_src_prev[((fx >> 16) << 1) + 1])))
-							SetPixelFast(x + j, y + i, contour_color);
+							setPixelFast(x + j, y + i, contour_color);
 					}
 
 					if (!cl && i != y0 && rle_alpha_b16(line_src_prev[((fx >> 16) << 1) + 1]))
-						SetPixel(x + j, y + i - iy, contour_color);
+						setPixel(x + j, y + i - iy, contour_color);
 				}
 				fx += dx;
 			}
-			if (cl) SetPixel(x + x1 - ix, y + i, contour_color);
+			if (cl) setPixel(x + x1 - ix, y + i, contour_color);
 		}
 		fx = (1 << 15);
 		for (int j = x0; j != x1; j += ix) {
 			const uint16 *line_src_prev = (y1 & 1) ? line0 : line1;
 			if (rle_alpha_b16(line_src_prev[((fx >> 16) << 1) + 1]))
-				SetPixel(x + j, y + y1 - iy, contour_color);
+				setPixel(x + j, y + y1 - iy, contour_color);
 			fx += dx;
 		}
 	}

--- a/system/graphics/gr_draw_sprite_rle.cpp
+++ b/system/graphics/gr_draw_sprite_rle.cpp
@@ -197,7 +197,7 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 			fx = (1 << 15);
 
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					const byte *src_data = line_src + (fx >> 16) * 3;
 					if (src_data[0] || src_data[1] || src_data[2])
 						SetPixelFast(x + j, y + i, make_rgb565u(src_data[2], src_data[1], src_data[0]));
@@ -214,7 +214,7 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 			fx = (1 << 15);
 
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					const byte *src_data = line_src + ((fx >> 16) << 2);
 
 					uint32 a = src_data[3];
@@ -441,7 +441,7 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 			fx = (1 << 15);
 
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					const byte *src_buf = line_src + ((fx >> 16) << 2);
 					if (src_buf[0] || src_buf[1] || src_buf[2]) {
 						uint16 scl;
@@ -464,7 +464,7 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 			fx = (1 << 15);
 
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					const byte *src_buf = line_src + ((fx >> 16) << 2);
 					uint32 a = src_buf[3];
 					if (a != 255) {
@@ -748,7 +748,7 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const class rleB
 
 			uint32 cl = 0;
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					cl = line_src[(fx >> 16) << 1];
 					if (!cl && j != x0 && line_src[((fx - dx) >> 16) << 1])
 						SetPixel(x + j - ix, y + i, contour_color);
@@ -788,7 +788,7 @@ void grDispatcher::DrawSprContour(int x, int y, int sx, int sy, const class rleB
 
 			bool cl = false;
 			for (int j = x0; j != x1; j += ix) {
-				if (ClipCheck(x + j, y + i)) {
+				if (clipCheck(x + j, y + i)) {
 					cl = rle_alpha_b16(line_src[((fx >> 16) << 1) + 1]);
 					if (!cl && j != x0 && rle_alpha_b16(line_src[(((fx - dx) >> 16) << 1) + 1]))
 						SetPixel(x + j - ix, y + i, contour_color);

--- a/system/graphics/gr_draw_sprite_rle.cpp
+++ b/system/graphics/gr_draw_sprite_rle.cpp
@@ -32,8 +32,8 @@
 
 namespace QDEngine {
 
-void grDispatcher::PutSpr_rle(int x, int y, int sx, int sy, const class rleBuffer *p, int mode, bool alpha_flag) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr_rle(%d, %d, %d, %d)", x, y, sx, sy);
+void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffer *p, int mode, bool alpha_flag) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr_rle(%d, %d, %d, %d)", x, y, sx, sy);
 
 	int px = 0;
 	int py = 0;
@@ -156,8 +156,8 @@ void grDispatcher::PutSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 	}
 }
 
-void grDispatcher::PutSpr_rle(int x, int y, int sx, int sy, const class rleBuffer *p, int mode, float scale, bool alpha_flag) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr_rle(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
+void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class rleBuffer *p, int mode, float scale, bool alpha_flag) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr_rle(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
 
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
@@ -236,8 +236,8 @@ void grDispatcher::PutSpr_rle(int x, int y, int sx, int sy, const class rleBuffe
 	}
 }
 
-void grDispatcher::PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, bool alpha_flag) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSprMask_rle(%d, %d, %d, %d)", x, y, sx, sy);
+void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, bool alpha_flag) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSprMask_rle(%d, %d, %d, %d)", x, y, sx, sy);
 
 	int px = 0;
 	int py = 0;
@@ -266,7 +266,7 @@ void grDispatcher::PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 	} else
 		dy = 1;
 
-	warning("STUB: grDispatcher::PutSprMask_rle");
+	warning("STUB: grDispatcher::putSprMask_rle");
 	for (int i = 0; i < psy; i++) {
 		uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
 
@@ -390,8 +390,8 @@ void grDispatcher::PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 	}
 }
 
-void grDispatcher::PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, float scale, bool alpha_flag) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSprMask_rle(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
+void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const rleBuffer *p, uint32 mask_color, int mask_alpha, int mode, float scale, bool alpha_flag) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSprMask_rle(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
 
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
@@ -488,7 +488,7 @@ void grDispatcher::PutSprMask_rle(int x, int y, int sx, int sy, const rleBuffer 
 		}
 }
 
-void grDispatcher::PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle) {
+void grDispatcher::putSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle) {
 	byte *buf = (byte *)temp_buffer(size.x * size.y * 4);
 
 	byte *buf_ptr = buf;
@@ -510,10 +510,10 @@ void grDispatcher::PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const r
 		}
 	}
 
-	PutSpr_rot(pos, size, buf, true, mode, angle);
+	putSpr_rot(pos, size, buf, true, mode, angle);
 }
 
-void grDispatcher::PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle, const Vect2f &scale) {
+void grDispatcher::putSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, int mode, float angle, const Vect2f &scale) {
 	byte *buf = (byte *)temp_buffer(size.x * size.y * 4);
 
 	byte *buf_ptr = buf;
@@ -535,10 +535,10 @@ void grDispatcher::PutSpr_rle_rot(const Vect2i &pos, const Vect2i &size, const r
 		}
 	}
 
-	PutSpr_rot(pos, size, buf, true, mode, angle, scale);
+	putSpr_rot(pos, size, buf, true, mode, angle, scale);
 }
 
-void grDispatcher::PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle) {
+void grDispatcher::putSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle) {
 	byte *buf = (byte *)temp_buffer(size.x * size.y * 4);
 
 	byte *buf_ptr = buf;
@@ -560,10 +560,10 @@ void grDispatcher::PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, con
 		}
 	}
 
-	PutSprMask_rot(pos, size, buf, true, mask_color, mask_alpha, mode, angle);
+	putSprMask_rot(pos, size, buf, true, mask_color, mask_alpha, mode, angle);
 }
 
-void grDispatcher::PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale) {
+void grDispatcher::putSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, const rleBuffer *data, bool has_alpha, uint32 mask_color, int mask_alpha, int mode, float angle, const Vect2f &scale) {
 	byte *buf = (byte *)temp_buffer(size.x * size.y * 4);
 
 	byte *buf_ptr = buf;
@@ -585,7 +585,7 @@ void grDispatcher::PutSprMask_rle_rot(const Vect2i &pos, const Vect2i &size, con
 		}
 	}
 
-	PutSprMask_rot(pos, size, buf, true, mask_color, mask_alpha, mode, angle, scale);
+	putSprMask_rot(pos, size, buf, true, mask_color, mask_alpha, mode, angle, scale);
 }
 
 inline bool rle_alpha_b(uint32 pixel) {

--- a/system/graphics/gr_draw_sprite_rle_z.cpp
+++ b/system/graphics/gr_draw_sprite_rle_z.cpp
@@ -27,8 +27,8 @@
 namespace QDEngine {
 
 #ifdef _GR_ENABLE_ZBUFFER
-void grDispatcher::PutSpr_rle_z(int x, int y, int z, int sx, int sy, const class rleBuffer *p, int mode, bool alpha_flag) {
-	debugC(2, kDebugGraphics, "grDispatcher::PutSpr_rle_z(%d, %d, %d, %d, %d)", x, y, z, sx, sy);
+void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class rleBuffer *p, int mode, bool alpha_flag) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr_rle_z(%d, %d, %d, %d, %d)", x, y, z, sx, sy);
 
 	int px = 0;
 	int py = 0;
@@ -441,7 +441,7 @@ void grDispatcher::PutSpr_rle_z(int x, int y, int z, int sx, int sy, const class
 	}
 }
 
-void grDispatcher::PutSpr_rle_z(int x, int y, int z, int sx, int sy, const class rleBuffer *p, int mode, float scale, bool alpha_flag) {
+void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class rleBuffer *p, int mode, float scale, bool alpha_flag) {
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
 

--- a/system/graphics/gr_draw_sprite_rle_z.cpp
+++ b/system/graphics/gr_draw_sprite_rle_z.cpp
@@ -486,7 +486,7 @@ void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class
 					if (ClipCheck(x + j, y + i)) {
 						uint32 cl = line_src[(fx >> 16) << 1];
 						if (cl) {
-							SetPixelFast(x + j, y + i, cl);
+							setPixelFast(x + j, y + i, cl);
 							put_z(x + j, y + i, z);
 						}
 					}
@@ -513,14 +513,14 @@ void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class
 							uint32 cl = line_src[(fx >> 16) << 1];
 
 							uint32 scl;
-							GetPixel(x + j, y + i, scl);
+							getPixel(x + j, y + i, scl);
 
 							scl = cl +
 							      (((((scl & mask_r) * a) >> 8) & mask_r) |
 							       ((((scl & mask_g) * a) >> 8) & mask_g) |
 							       ((((scl & mask_b) * a) >> 8) & mask_b));
 
-							SetPixelFast(x + j, y + i, scl);
+							setPixelFast(x + j, y + i, scl);
 							put_z(x + j, y + i, z);
 						}
 					}
@@ -551,7 +551,7 @@ void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class
 						uint32 b = line_src[idx + 0];
 
 						if (r || g || b) {
-							SetPixelFast(x + j, y + i, r, g, b);
+							setPixelFast(x + j, y + i, r, g, b);
 							put_z(x + j, y + i, z);
 						}
 					}
@@ -572,13 +572,13 @@ void grDispatcher::putSpr_rle_z(int x, int y, int z, int sx, int sy, const class
 						uint32 a = line_src[idx + 3];
 						if (a != 255) {
 							uint32 sr, sg, sb;
-							GetPixel(x + j, y + i, sr, sg, sb);
+							getPixel(x + j, y + i, sr, sg, sb);
 
 							uint32 r = line_src[idx + 2] + ((a * sr) >> 8);
 							uint32 g = line_src[idx + 1] + ((a * sg) >> 8);
 							uint32 b = line_src[idx + 0] + ((a * sb) >> 8);
 
-							SetPixelFast(x + j, y + i, r, g, b);
+							setPixelFast(x + j, y + i, r, g, b);
 							put_z(x + j, y + i, z);
 						}
 					}

--- a/system/graphics/gr_draw_sprite_z.cpp
+++ b/system/graphics/gr_draw_sprite_z.cpp
@@ -73,8 +73,8 @@ void grDispatcher::putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p
 					uint32 a = line_src[((fx >> 16) << 1) + 1];
 					if (a != 255 && ClipCheck(x + j, y + i)) {
 						uint32 sc;
-						GetPixel(x + j, y + i, sc);
-						SetPixel(x + j, y + i, alpha_blend_555(line_src[(fx >> 16) << 1], sc, a));
+						getPixel(x + j, y + i, sc);
+						setPixel(x + j, y + i, alpha_blend_555(line_src[(fx >> 16) << 1], sc, a));
 						put_z(x + j, y + i, z);
 					}
 					fx += dx;
@@ -91,8 +91,8 @@ void grDispatcher::putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p
 					uint32 a = line_src[((fx >> 16) << 1) + 1];
 					if (a != 255 && ClipCheck(x + j, y + i)) {
 						uint32 sc;
-						GetPixel(x + j, y + i, sc);
-						SetPixel(x + j, y + i, alpha_blend_565(line_src[(fx >> 16) << 1], sc, a));
+						getPixel(x + j, y + i, sc);
+						setPixel(x + j, y + i, alpha_blend_565(line_src[(fx >> 16) << 1], sc, a));
 						put_z(x + j, y + i, z);
 					}
 					fx += dx;
@@ -115,13 +115,13 @@ void grDispatcher::putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p
 				uint32 a = line_src[idx + 3];
 				if (a != 255 && ClipCheck(x + j, y + i)) {
 					uint32 sr, sg, sb;
-					GetPixel(x + j, y + i, sr, sg, sb);
+					getPixel(x + j, y + i, sr, sg, sb);
 
 					uint32 r = line_src[idx + 2] + ((a * sr) >> 8);
 					uint32 g = line_src[idx + 1] + ((a * sg) >> 8);
 					uint32 b = line_src[idx + 0] + ((a * sb) >> 8);
 
-					SetPixel(x + j, y + i, r, g, b);
+					setPixel(x + j, y + i, r, g, b);
 					put_z(x + j, y + i, z);
 				}
 
@@ -175,7 +175,7 @@ void grDispatcher::putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, 
 			for (int j = x0; j != x1; j += ix) {
 				uint32 cl = line_src[fx >> 16];
 				if (cl) {
-					SetPixel(x + j, y + i, cl);
+					setPixel(x + j, y + i, cl);
 					put_z(x + j, y + i, z);
 				}
 				fx += dx;
@@ -200,7 +200,7 @@ void grDispatcher::putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, 
 				uint32 b = line_src[idx + 0];
 
 				if (r || g || b) {
-					SetPixel(x + j, y + i, r, g, b);
+					setPixel(x + j, y + i, r, g, b);
 					put_z(x + j, y + i, z);
 				}
 
@@ -222,7 +222,7 @@ void grDispatcher::putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, 
 			for (int j = x0; j != x1; j += ix) {
 				uint32 cl = line_src[fx >> 16];
 				if (cl) {
-					SetPixel(x + j, y + i, cl);
+					setPixel(x + j, y + i, cl);
 					put_z(x + j, y + i, z);
 				}
 				fx += dx;

--- a/system/graphics/gr_draw_sprite_z.cpp
+++ b/system/graphics/gr_draw_sprite_z.cpp
@@ -26,7 +26,7 @@
 namespace QDEngine {
 
 #ifdef _GR_ENABLE_ZBUFFER
-void grDispatcher::PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale) {
+void grDispatcher::putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale) {
 	int i, j, sx_dest, sy_dest;
 
 	sx_dest = round(float(sx) * scale);
@@ -132,7 +132,7 @@ void grDispatcher::PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p
 	}
 }
 
-void grDispatcher::PutSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale) {
+void grDispatcher::putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode, float scale) {
 	int sx_dest = round(float(sx) * scale);
 	int sy_dest = round(float(sy) * scale);
 
@@ -232,7 +232,7 @@ void grDispatcher::PutSpr_z(int x, int y, int z, int sx, int sy, const byte *p, 
 	}
 }
 
-void grDispatcher::PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode) {
+void grDispatcher::putSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p, int mode) {
 	int px = 0;
 	int py = 0;
 
@@ -412,7 +412,7 @@ void grDispatcher::PutSpr_a_z(int x, int y, int z, int sx, int sy, const byte *p
 	}
 }
 
-void grDispatcher::PutSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode) {
+void grDispatcher::putSpr_z(int x, int y, int z, int sx, int sy, const byte *p, int mode) {
 	int px = 0;
 	int py = 0;
 

--- a/system/graphics/gr_tile_animation.cpp
+++ b/system/graphics/gr_tile_animation.cpp
@@ -276,7 +276,7 @@ void grTileAnimation::drawFrame(const Vect2i &position, int frame_index, float a
 		}
 	}
 
-	grDispatcher::instance()->PutSpr_rot(position, _frameSize, buf, _hasAlpha, mode, angle);
+	grDispatcher::instance()->putSpr_rot(position, _frameSize, buf, _hasAlpha, mode, angle);
 }
 
 } // namespace QDEngine

--- a/system/input/mouse_input.cpp
+++ b/system/input/mouse_input.cpp
@@ -42,10 +42,10 @@ mouseDispatcher *mouseDispatcher::instance() {
 }
 
 bool mouseDispatcher::handle_event(mouseEvent ev, int x, int y, int flags) {
-	if (x >= grDispatcher::instance()->Get_SizeX())
-		x = grDispatcher::instance()->Get_SizeX() - 1;
-	if (y >= grDispatcher::instance()->Get_SizeY())
-		y = grDispatcher::instance()->Get_SizeY() - 1;
+	if (x >= grDispatcher::instance()->get_SizeX())
+		x = grDispatcher::instance()->get_SizeX() - 1;
+	if (y >= grDispatcher::instance()->get_SizeY())
+		y = grDispatcher::instance()->get_SizeY() - 1;
 
 	if (_event_handlers[ev])
 		(*_event_handlers[ev])(x, y, flags);


### PR DESCRIPTION
This PR involves the renaming of all the methods so that they start with a lower case letter instead of an uppercase one.