### PR TITLE
Fix Warnings and Graphics

### DIFF
--- a/qdcore/qd_animation_set.cpp
+++ b/qdcore/qd_animation_set.cpp
@@ -252,7 +252,7 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 			fh.writeString("\t");
 		}
 
-		fh.writeString(Common::String::format("<walk_sound_frequency>%lu", _walk_sound_frequency.size()));
+		fh.writeString(Common::String::format("<walk_sound_frequency>%u", _walk_sound_frequency.size()));
 		for (int i = 0; i < _walk_sound_frequency.size(); i++) {
 			fh.writeString(Common::String::format(" %f", _walk_sound_frequency[i]));
 		}

--- a/qdcore/qd_condition_group.cpp
+++ b/qdcore/qd_condition_group.cpp
@@ -90,7 +90,7 @@ bool qdConditionGroup::save_script(Common::WriteStream &fh, int indent) const {
 	fh.writeString(Common::String::format(" type=\"%d\"", (int)_conditions_mode));
 	fh.writeString(">");
 
-	fh.writeString(Common::String::format("%lu", _conditions.size()));
+	fh.writeString(Common::String::format("%u", _conditions.size()));
 	for (auto &it : _conditions) {
 		fh.writeString(Common::String::format(" %d", it));
 	}

--- a/qdcore/qd_game_dispatcher.cpp
+++ b/qdcore/qd_game_dispatcher.cpp
@@ -2495,13 +2495,13 @@ bool qdGameDispatcher::load_save(Common::SeekableReadStream *fh) {
 	size = fh->readUint32LE();
 	if (size != scene_list().size()) return false;
 
-	debugC(3, kDebugLog, "Scene list size: %zu pos: %ld", scene_list().size(), fh->pos());
+	debugC(3, kDebugLog, "Scene list size: %u pos: %ld", scene_list().size(), fh->pos());
 	for (auto &it : scene_list()) {
 		if (!it->load_data(*fh, save_version))
 			return false;
 	}
 
-	debugC(3, kDebugLog, "Global object list size: %zu pos: %ld", global_object_list().size(), fh->pos());
+	debugC(3, kDebugLog, "Global object list size: %u pos: %ld", global_object_list().size(), fh->pos());
 
 	debugC(2, kDebugSave, "qdGameDispatcher::load_save(): object_list 2 %ld", fh->pos());
 	size = fh->readSint32LE();
@@ -2605,13 +2605,13 @@ bool qdGameDispatcher::save_save(Common::WriteStream *fh) const {
 
 	debugC(2, kDebugSave, "qdGameDispatcher::save_save(): scene_list %ld", fh->pos());
 	fh->writeUint32LE(scene_list().size());
-	debugC(3, kDebugLog, "Scene list size: %zu pos: %ld", scene_list().size(), fh->pos());
+	debugC(3, kDebugLog, "Scene list size: %u pos: %ld", scene_list().size(), fh->pos());
 	for (auto &it : scene_list()) {
 		if (!it->save_data(*fh))
 			return false;
 	}
 
-	debugC(3, kDebugLog, "Global object list size: %zu pos: %ld", global_object_list().size(), fh->pos());
+	debugC(3, kDebugLog, "Global object list size: %u pos: %ld", global_object_list().size(), fh->pos());
 
 	debugC(2, kDebugSave, "qdGameDispatcher::save_save(): object_list 2 %ld", fh->pos());
 	fh->writeUint32LE(global_object_list().size());

--- a/qdcore/qd_game_object_moving.cpp
+++ b/qdcore/qd_game_object_moving.cpp
@@ -344,7 +344,7 @@ bool qdGameObjectMoving::enough_far_target(const Vect3f &dest) const {
 template<class V>
 void dump_vect(const V &vect) {
 	debugC(3, kDebugLog, "------------");
-	debugC(3, kDebugLog, "%zu", vect.size());
+	debugC(3, kDebugLog, "%u", vect.size());
 
 	for (int i = 0; i < vect.size(); i++) {
 		debugC(3, kDebugLog, "%d %d", (int)vect[i].x, (int)vect[i].y);

--- a/qdcore/qd_game_object_state.cpp
+++ b/qdcore/qd_game_object_state.cpp
@@ -1218,7 +1218,7 @@ bool qdGameObjectStateWalk::save_script(Common::WriteStream &fh, int indent) con
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<center_offsets>%lu", _center_offsets.size() * 2));
+		fh.writeString(Common::String::format("<center_offsets>%u", _center_offsets.size() * 2));
 		for (int i = 0; i < _center_offsets.size(); i++) {
 			fh.writeString(Common::String::format(" %d %d", _center_offsets[i].x, _center_offsets[i].y));
 		}
@@ -1229,7 +1229,7 @@ bool qdGameObjectStateWalk::save_script(Common::WriteStream &fh, int indent) con
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<static_center_offsets>%lu", _static_center_offsets.size() * 2));
+		fh.writeString(Common::String::format("<static_center_offsets>%u", _static_center_offsets.size() * 2));
 		for (int i = 0; i < _static_center_offsets.size(); i++) {
 			fh.writeString(Common::String::format(" %d %d", _static_center_offsets[i].x, _static_center_offsets[i].y));
 		}
@@ -1240,7 +1240,7 @@ bool qdGameObjectStateWalk::save_script(Common::WriteStream &fh, int indent) con
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<start_center_offsets>%lu", _start_center_offsets.size() * 2));
+		fh.writeString(Common::String::format("<start_center_offsets>%u", _start_center_offsets.size() * 2));
 		for (int i = 0; i < _start_center_offsets.size(); i++){
 			fh.writeString(Common::String::format(" %d %d", _start_center_offsets[i].x, _start_center_offsets[i].y));
 		}
@@ -1251,7 +1251,7 @@ bool qdGameObjectStateWalk::save_script(Common::WriteStream &fh, int indent) con
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<stop_center_offsets>%lu", _stop_center_offsets.size() * 2));
+		fh.writeString(Common::String::format("<stop_center_offsets>%u", _stop_center_offsets.size() * 2));
 		for (int i = 0; i < _stop_center_offsets.size(); i++) {
 			fh.writeString(Common::String::format(" %d %d", _stop_center_offsets[i].x, _stop_center_offsets[i].y));
 		}
@@ -1262,7 +1262,7 @@ bool qdGameObjectStateWalk::save_script(Common::WriteStream &fh, int indent) con
 		for (int i = 0; i <= indent; i++) {
 			fh.writeString("\t");
 		}
-		fh.writeString(Common::String::format("<walk_sound_frequency>%lu", _walk_sound_frequency.size()));
+		fh.writeString(Common::String::format("<walk_sound_frequency>%u", _walk_sound_frequency.size()));
 		for (int i = 0; i < _walk_sound_frequency.size(); i++) {
 			fh.writeString(Common::String::format(" %f", _walk_sound_frequency[i]));
 		}

--- a/qdcore/qd_game_scene.cpp
+++ b/qdcore/qd_game_scene.cpp
@@ -750,7 +750,7 @@ bool qdGameScene::load_data(Common::SeekableReadStream &fh, int save_version) {
 	if (!_camera.load_data(fh, save_version))
 		return false;
 
-	debugC(3, kDebugSave, "  qdGameScene::load_data(%zu): Loading _objects %ld", object_list().size(), fh.pos());
+	debugC(3, kDebugSave, "  qdGameScene::load_data(%u): Loading _objects %ld", object_list().size(), fh.pos());
 	for (auto &it : object_list()) {
 		if (!it->load_data(fh, save_version)) {
 			return false;
@@ -825,7 +825,7 @@ bool qdGameScene::save_data(Common::WriteStream &fh) const {
 		return false;
 	}
 
-	debugC(3, kDebugSave, "  qdGameSceen::save_data(%zu): Saving _objects %ld", object_list().size(), fh.pos());
+	debugC(3, kDebugSave, "  qdGameSceen::save_data(%u): Saving _objects %ld", object_list().size(), fh.pos());
 	for (auto &it : object_list()) {
 		if (!it->save_data(fh)) {
 			return false;

--- a/qdcore/qd_interface_screen.cpp
+++ b/qdcore/qd_interface_screen.cpp
@@ -227,7 +227,7 @@ bool qdInterfaceScreen::is_element_in_list(const qdInterfaceElement *el) const {
 }
 
 bool qdInterfaceScreen::mouse_handler(int x, int y, mouseDispatcher::mouseEvent ev) {
-	debugC(9, kDebugInput, "qdInterfaceScreen::mouse_handler(%d, %d, %lu)", x, y, _sorted_elements.size());
+	debugC(9, kDebugInput, "qdInterfaceScreen::mouse_handler(%d, %d, %u)", x, y, _sorted_elements.size());
 	if (qdInterfaceDispatcher *dp = dynamic_cast<qdInterfaceDispatcher* >(owner())) {
 		for (auto &it : _sorted_elements) {
 			if (it->hit_test(x, y)) {

--- a/qdcore/qd_inventory.cpp
+++ b/qdcore/qd_inventory.cpp
@@ -305,7 +305,7 @@ void qdInventory::remove_cell_set(int idx) {
 }
 
 bool qdInventory::load_resources() {
-	debugC(4, kDebugLoad, "qdInventory::load_resources(), %lu cells", _cell_sets.size());
+	debugC(4, kDebugLoad, "qdInventory::load_resources(), %u cells", _cell_sets.size());
 
 	for (auto &it : _cell_sets)
 		it.load_resources();

--- a/qdcore/qd_sprite.cpp
+++ b/qdcore/qd_sprite.cpp
@@ -633,7 +633,7 @@ void qdSprite::redraw(int x, int y, int z, int mode) const {
 		if (check_flag(ALPHA_FLAG))
 			grDispatcher::instance()->putSpr_a(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
 		else
-			grDispatcher::instance()->putSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode);
+			grDispatcher::instance()->putSpr(xx, yy, _picture_size.x, _picture_size.y, _data, mode, _format);
 	} else
 		grDispatcher::instance()->putSpr_rle(xx, yy, _picture_size.x, _picture_size.y, _rle_data, mode, check_flag(ALPHA_FLAG));
 #endif

--- a/system/graphics/gr_dispatcher.h
+++ b/system/graphics/gr_dispatcher.h
@@ -179,8 +179,8 @@ public:
 
 	void fill(int val);
 
-	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode);
-	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale);
+	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode, int spriteFormat);
+	void putSpr(int x, int y, int sx, int sy, const byte *p, int mode, int spriteFormat, float scale);
 	void putSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, bool alpha_flag);
 	void putSpr_rle(int x, int y, int sx, int sy, const rleBuffer *p, int mode, float scale, bool alpha_flag);
 	void putSpr_a(int x, int y, int sx, int sy, const byte *p, int mode);

--- a/system/graphics/gr_draw_sprite.cpp
+++ b/system/graphics/gr_draw_sprite.cpp
@@ -87,7 +87,7 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 	}
 }
 
-void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode, float scale) {
+void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode, int spriteFormat, float scale) {
 	debugC(2, kDebugGraphics, "grDispatcher::putSpr(%d, %d, %d, %d, scale=%f)", x, y, sx, sy, scale);
 
 	int sx_dest = round(float(sx) * scale);
@@ -589,8 +589,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	}
 }
 
-void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode) {
-	debugC(2, kDebugGraphics, "grDispatcher::putSpr(%d, %d, %d, %d)", x, y, sx, sy);
+void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode, int spriteFormat) {
+	debugC(2, kDebugGraphics, "grDispatcher::putSpr(%d, %d, %d, %d, %d)", x, y, sx, sy, spriteFormat);
 
 	int px = 0;
 	int py = 0;
@@ -614,12 +614,12 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode)
 	} else
 		dy = 1;
 
-	sx *= bytes_per_pixel();
-	px *= bytes_per_pixel();
+	if (spriteFormat == GR_RGB888) {
+		sx *= 3;
+		px *= 3;
 
-	const byte *data_ptr = p + py * sx;
+		const byte *data_ptr = p + py * sx;
 
-	if (bytes_per_pixel() == 3) {
 		for (int i = 0; i < psy; i++) {
 			uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
 			const byte *data_line = data_ptr + px;
@@ -634,7 +634,12 @@ void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode)
 			data_ptr += sx;
 			y += dy;
 		}
-	} else if (bytes_per_pixel() == 2) {
+	} else if (spriteFormat == GR_RGB565) {
+		sx *= 2;
+		px *= 2;
+
+		const byte *data_ptr = p + py * sx;
+
 		for (int i = 0; i < psy; i++) {
 			uint16 *scr_buf = reinterpret_cast<uint16 *>(_screenBuf->getBasePtr(x, y));
 			const byte *data_line = data_ptr + px;

--- a/system/graphics/gr_tile_animation.cpp
+++ b/system/graphics/gr_tile_animation.cpp
@@ -78,7 +78,7 @@ void grTileAnimation::init(int frame_count, const Vect2i &frame_size, bool alpha
 void grTileAnimation::compact() {
 	TileOffsets(_tileOffsets).swap(_tileOffsets);
 	TileData(_tileData).swap(_tileData);
-	debugC(3, kDebugLog, "Tile animation: %lu Kbytes", (_frameIndex.size() + _tileData.size() + _tileOffsets.size()) * 4 / 1024);
+	debugC(3, kDebugLog, "Tile animation: %u Kbytes", (_frameIndex.size() + _tileData.size() + _tileOffsets.size()) * 4 / 1024);
 }
 
 bool grTileAnimation::compress(grTileCompressionMethod method) {


### PR DESCRIPTION
This PR involves the following changes
- Fix warnings after changing switching from `std::vector` to `Std::vector`
- Add a parameter to the `putSpr` method to check for the format of the sprite. 